### PR TITLE
Add instructions for setting up local development environment, Python and JavaScript code examples in documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,7 +21,11 @@
 7. You should now be able to access the project running locally on https://localhost:7007. If you encounter an error message about your connection not being secure and you are running Chrome, refer to [this](https://stackoverflow.com/questions/44066709/your-connection-is-not-private-neterr-cert-common-name-invalid) Stack Overflow post.
 
 ## How to run frontend tests
-1. Click Manage NuGet Packages and find and install Chutzpah
+*** Note ***
+As of 6/14/2023, the tests in the first two describe functions pass, however, the tests for the event listener functions in the third describe function will not pass and instead error out with a message about a reference to JSDOM. I wasn't able to find a way to pass in a reference to JSDOM in the test file with Chutzpah, and didn't see anything about marking tests to skip in the documentation.
+1. Click Manage NuGet Packages and find and install [Chutzpah](https://mmanela.github.io/chutzpah/)
 2. If it was installed globally it should be installed under %userprofile%/.nuget (for me this is C:\Users\benja\\.nuget). You'll need the path to the exectuable in the chutzpah packages folder to run the tests. The executable should be named `chutzpah.console.exe`
 3. Once you've located the exectuable run `[[path/to/exectuable]] [[path/to/test.js]] /openInBrowser [[your preferred browser]]` (The relative path to test.js from root of the project is `.\tests\AnApiOfIceAndFire.Tests\Views\test.js`)
 4. I'm not sure why, but passing the /openInBrowser option was the only way I was able to get the relative path to script.js to resolve so the tests would run.
+
+

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,3 +10,12 @@
 ## Worth noting
 * All contributions are welcome, it doesn't matter if it's a big feature or a small data fix.
 * The data files are located [here](https://github.com/joakimskoog/AnApiOfIceAndFire/tree/master/data)
+
+## Set up local development
+1. Fork this repository
+2. Git clone your fork (for more information about forking and cloning refer [here](https://docs.github.com/en/get-started/quickstart/contributing-to-projects))
+3. Download and install [Visual Studio Community 2022](https://visualstudio.microsoft.com/vs/community/). .NET 6.0 requires the 2022 version.
+4. Download and install [.NET 6.0](https://dotnet.microsoft.com/en-us/download/dotnet/6.0). On Windows, to check which architecture version you need to download (x86, x64, Arm64) search for and open System Information in the Windows search bar and then look for System Type.
+5. Right click on the [AnApiOfIceAndFire.sln] file in the top level directory of the project and open with Visual Studio 2022.
+6. Once the project is opened in Visual Studio, click Run in the top menu bar or click F5. This will build and run the project. If you encounter errors during the build process, make sure you followed the steps above to install the correct tools. Otherwise, try right clicking on the solution in the Solution Explorer and selecting "Restore NuGet Packages". 
+7. You should now be able to access the project running locally on https://localhost:7007. If you encounter an error message about your connection not being secure and you are running Chrome, refer to [this](https://stackoverflow.com/questions/44066709/your-connection-is-not-private-neterr-cert-common-name-invalid) Stack Overflow post.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,11 +11,11 @@
 * All contributions are welcome, it doesn't matter if it's a big feature or a small data fix.
 * The data files are located [here](https://github.com/joakimskoog/AnApiOfIceAndFire/tree/master/data)
 
-## Set up local development
+## How to set up local development
 1. Fork this repository
 2. Git clone your fork (for more information about forking and cloning refer [here](https://docs.github.com/en/get-started/quickstart/contributing-to-projects))
 3. Download and install [Visual Studio Community 2022](https://visualstudio.microsoft.com/vs/community/). .NET 6.0 requires the 2022 version.
 4. Download and install [.NET 6.0](https://dotnet.microsoft.com/en-us/download/dotnet/6.0). On Windows, to check which architecture version you need to download (x86, x64, Arm64) search for and open System Information in the Windows search bar and then look for System Type.
-5. Right click on the [AnApiOfIceAndFire.sln] file in the top level directory of the project and open with Visual Studio 2022.
+5. Right click on the `AnApiOfIceAndFire.sln` file in the top level directory of the project and open with Visual Studio 2022.
 6. Once the project is opened in Visual Studio, click Run in the top menu bar or click F5. This will build and run the project. If you encounter errors during the build process, make sure you followed the steps above to install the correct tools. Otherwise, try right clicking on the solution in the Solution Explorer and selecting "Restore NuGet Packages". 
 7. You should now be able to access the project running locally on https://localhost:7007. If you encounter an error message about your connection not being secure and you are running Chrome, refer to [this](https://stackoverflow.com/questions/44066709/your-connection-is-not-private-neterr-cert-common-name-invalid) Stack Overflow post.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,3 +19,9 @@
 5. Right click on the `AnApiOfIceAndFire.sln` file in the top level directory of the project and open with Visual Studio 2022.
 6. Once the project is opened in Visual Studio, click Run in the top menu bar or click F5. This will build and run the project. If you encounter errors during the build process, make sure you followed the steps above to install the correct tools. Otherwise, try right clicking on the solution in the Solution Explorer and selecting "Restore NuGet Packages". 
 7. You should now be able to access the project running locally on https://localhost:7007. If you encounter an error message about your connection not being secure and you are running Chrome, refer to [this](https://stackoverflow.com/questions/44066709/your-connection-is-not-private-neterr-cert-common-name-invalid) Stack Overflow post.
+
+## How to run frontend tests
+1. Click Manage NuGet Packages and find and install Chutzpah
+2. If it was installed globally it should be installed under %userprofile%/.nuget (for me this is C:\Users\benja\\.nuget). You'll need the path to the exectuable in the chutzpah packages folder to run the tests. The executable should be named `chutzpah.console.exe`
+3. Once you've located the exectuable run `[[path/to/exectuable]] [[path/to/test.js]] /openInBrowser [[your preferred browser]]` (The relative path to test.js from root of the project is `.\tests\AnApiOfIceAndFire.Tests\Views\test.js`)
+4. I'm not sure why, but passing the /openInBrowser option was the only way I was able to get the relative path to script.js to resolve so the tests would run.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,7 +13,7 @@
 
 ## How to set up local development
 1. Fork this repository
-2. Git clone your fork (for more information about forking and cloning refer [here](https://docs.github.com/en/get-started/quickstart/contributing-to-projects))
+2. Git clone your fork (for information on forking and cloning refer [here](https://docs.github.com/en/get-started/quickstart/contributing-to-projects))
 3. Download and install [Visual Studio Community 2022](https://visualstudio.microsoft.com/vs/community/). .NET 6.0 requires the 2022 version.
 4. Download and install [.NET 6.0](https://dotnet.microsoft.com/en-us/download/dotnet/6.0). On Windows, to check which architecture version you need to download (x86, x64, Arm64) search for and open System Information in the Windows search bar and then look for System Type.
 5. Right click on the `AnApiOfIceAndFire.sln` file in the top level directory of the project and open with Visual Studio 2022.

--- a/src/AnApiOfIceAndFire/AnApiOfIceAndFire.csproj
+++ b/src/AnApiOfIceAndFire/AnApiOfIceAndFire.csproj
@@ -3,6 +3,10 @@
     <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 	<ItemGroup>
+	  <None Include="wwwroot\script.js" />
+	</ItemGroup>
+	<ItemGroup>
+		<PackageReference Include="Chutzpah" Version="4.4.13" />
 		<PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning" Version="5.0.0" />
 	</ItemGroup>
 	<ItemGroup>

--- a/src/AnApiOfIceAndFire/Views/Documentation/Index.cshtml
+++ b/src/AnApiOfIceAndFire/Views/Documentation/Index.cshtml
@@ -2,56 +2,53 @@
     ViewData["Title"] = "Documentation";
 }
 
+<style>
+    code {
+        display: block;
+    }
+</style>
+
 <script>
 
     const jsonCodeData = {
         "root": {
             "curl": "$ \"https://www.anapioficeandfire.com/api\"",
-                "python": "this is the python code snippet",
-                    "js": "this is the js code snippet"
+            "python": "\nimport logging\nimport requests\nurl = \"https://www.anapioficeandfire.com/api\"\nresp = requests.get(url)\nif resp.status_code == 200:\n    data = resp.json()\nelse:\n    logging.info(f\"Error on request to {url}: {resp.text}\")\n ",
+            "js": "\nconst loadData = async () => {\n  const url = \"https://www.anapioficeandfire.com/api\";\n  const resp = await fetch(url);\n  if (resp.status === 200) {\n    const data = await resp.json();\n  } else {\n    console.log(\"Error on request. Error status code: \", resp.status)\n}\n ",
         },
         "allBooks": {
             "curl": "$ \"https://www.anapioficeandfire.com/api/books\"",
-                "python": "this is the python code snippet",
-                    "js": "this is the js code snippet"
+            "python": "\nimport logging\nimport requests\nurl = \"https://www.anapioficeandfire.com/api/books\"\nresp = requests.get(url)\nif resp.status_code == 200:\n    data = resp.json()\nelse:\n    logging.info(f\"Error on request to {url}: {resp.text}\")\n ",
+            "js": "\nconst loadData = async () => {\n  const url = \"https://www.anapioficeandfire.com/api/books\";\n  const resp = await fetch(url);\n  if (resp.status === 200) {\n    const data = await resp.json();\n  } else {\n    console.log(\"Error on request. Error status code: \", resp.status)\n}\n "
         },
         "specificBook": {
             "curl": "$ curl \"https://www.anapioficeandfire.com/api/books/1\"",
-                "python": "",
-                    "js": ""
+            "python": "\nimport logging\nimport requests\nurl = \"https://www.anapioficeandfire.com/api/books/1\"\nresp = requests.get(url)\nif resp.status_code == 200:\n    data = resp.json()\nelse:\n    logging.info(f\"Error on request to {url}: {resp.text}\")\n ",
+            "js": "\nconst loadData = async () => {\n  const url = \"https://www.anapioficeandfire.com/api/books/1\";\n  const resp = await fetch(url);\n  if (resp.status === 200) {\n    const data = await resp.json();\n  } else {\n    console.log(\"Error on request. Error status code: \", resp.status)\n}\n "
         },
         "allCharacters": {
             "curl": "$ curl \"https://www.anapioficeandfire.com/api/characters\"",
-                "python": "",
-                    "js": ""
+            "python": "\nimport logging\nimport requests\nurl = \"https://www.anapioficeandfire.com/api/characters\"\nresp = requests.get(url)\nif resp.status_code == 200:\n    data = resp.json()\nelse:\n    logging.info(f\"Error on request to {url}: {resp.text}\")\n ",
+            "js": "\nconst loadData = async () => {\n  const url = \"https://www.anapioficeandfire.com/api/characters\";\n  const resp = await fetch(url);\n  if (resp.status === 200) {\n    const data = await resp.json();\n  } else {\n    console.log(\"Error on request. Error status code: \", resp.status)\n}\n "
         },
         "specificCharacter": {
             "curl": "$ curl \"https://www.anapioficeandfire.com/api/characters/823\"",
-                "python": "",
-                    "js": ""
+            "python": "\nimport logging\nimport requests\nurl = \"https://www.anapioficeandfire.com/api/characters/823\"\nresp = requests.get(url)\nif resp.status_code == 200:\n    data = resp.json()\nelse:\n    logging.info(f\"Error on request to {url}: {resp.text}\")\n ",
+            "js": "\nconst loadData = async () => {\n  const url = \"https://www.anapioficeandfire.com/api/characters/823\";\n  const resp = await fetch(url);\n  if (resp.status === 200) {\n    const data = await resp.json();\n  } else {\n    console.log(\"Error on request. Error status code: \", resp.status)\n}\n "
         },
         "allHouses": {
             "curl": "$ curl \"https://www.anapioficeandfire.com/api/houses\"",
-                "python": "",
-                    "js": ""
+            "python": "\nimport logging\nimport requests\nurl = \"https://www.anapioficeandfire.com/api/houses\"\nresp = requests.get(url)\nif resp.status_code == 200:\n    data = resp.json()\nelse:\n    logging.info(f\"Error on request to {url}: {resp.text}\")\n ",
+            "js": "\nconst loadData = async () => {\n  const url = \"https://www.anapioficeandfire.com/api/houses\";\n  const resp = await fetch(url);\n  if (resp.status === 200) {\n    const data = await resp.json();\n  } else {\n    console.log(\"Error on request. Error status code: \", resp.status)\n}\n "
         },
         "specificHouse": {
             "curl": "$ curl \"https://www.anapioficeandfire.com/api/houses/10\"",
-                "python": "",
-                    "js": ""
+            "python": "\nimport logging\nimport requests\nurl = \"https://www.anapioficeandfire.com/api/houses/10\"\nresp = requests.get(url)\nif resp.status_code == 200:\n    data = resp.json()\nelse:\n    logging.info(f\"Error on request to {url}: {resp.text}\")\n ",
+            "js": "\nconst loadData = async () => {\n  const url = \"https://www.anapioficeandfire.com/api/houses/10\";\n  const resp = await fetch(url);\n  if (resp.status === 200) {\n    const data = await resp.json();\n  } else {\n    console.log(\"Error on request. Error status code: \", resp.status)\n}\n "
         }
     }
 
-    const setCodeSnippet = (e) => {
-        const dropDownElem = document.getElementById(e.target.id);
-        const lang = e.target.value;
-        const key = e.target.id.slice(0, e.target.id.indexOf("-"));
-        const codeElem = document.getElementById(key + "-req-code");
-        const codeSnippet = jsonCodeData[key][lang];
-        codeElem.innerHTML = codeSnippet;
-    }
-
-    const dropDownIds = [
+    const elemIdRoots = [
         "root",
         "allBooks",
         "specificBook",
@@ -61,10 +58,20 @@
         "specificHouse",
     ]
 
+    const setCodeSnippets = (e) => {
+        elemIdRoots.forEach(id => {
+            const codeElem = document.getElementById(id + "-req-code");
+            const codeSnippet = jsonCodeData[id][e.target.value];
+            codeElem.innerText = codeSnippet;
+            const dropDownElem = document.getElementById(id + "-req-lang");
+            dropDownElem.value = e.target.value;
+        })
+    }
+
     document.addEventListener("DOMContentLoaded", () => {
-        dropDownIds.forEach(id => {
+        elemIdRoots.forEach(id => {
             const elem = document.getElementById(id + "-req-lang");
-            elem.addEventListener("change", setCodeSnippet);
+            elem.addEventListener("change", setCodeSnippets);
         });
     })
 
@@ -195,7 +202,9 @@
                                     <option value="python">Python</option>
                                     <option value="js">JavaScript</option>
                                 </select>
-                                <code id="root-req-code"></code>
+                                <pre>
+                                    <code id="root-req-code">$ curl "https://www.anapioficeandfire.com/api"</code>
+                                </pre>
                                 <h5>Example response:</h5>
                                 <pre><code>{
     "books": "https://www.anapioficeandfire.com/api/books",
@@ -281,7 +290,9 @@
                                         <option value="python">Python</option>
                                         <option value="js">JavaScript</option>
                                     </select>
-                                    <code id="allBooks-req-code"></code>
+                                    <pre>
+                                        <code id="allBooks-req-code">$ curl "https://www.anapioficeandfire.com/api/books"</code>
+                                    </pre>
                                     <p>
                                         <strong>Example response:</strong>
                                     </p>
@@ -366,7 +377,9 @@
                                         <option value="python">Python</option>
                                         <option value="js">JavaScript</option>
                                     </select>
-                                    <code id="specificBook-req-code"></code>
+                                    <pre>
+                                        <code id="specificBook-req-code">$ curl "https://www.anapioficeandfire.com/api/books/1"</code>
+                                    </pre>
                                     <p>
                                         <strong>Example response:</strong>
                                     </p>
@@ -495,7 +508,9 @@
                                         <option value="python">Python</option>
                                         <option value="js">JavaScript</option>
                                     </select>
-                                    <code id="allCharacters-req-code"></code>
+                                    <pre>
+                                        <code id="allCharacters-req-code">$ curl "https://www.anapioficeandfire.com/api/characters"</code>
+                                    </pre>
                                     <p>
                                         <strong>Example response:</strong>
                                     </p>
@@ -606,7 +621,9 @@
                                         <option value="python">Python</option>
                                         <option value="js">JavaScript</option>
                                     </select>
-                                    <code id="specificCharacter-req-code"></code>
+                                    <pre>
+                                        <code id="specificCharacter-req-code">$ curl "https://www.anapioficeandfire.com/api/characters/823"</code>
+                                    </pre>
                                     <p>
                                         <strong>Example response:</strong>
                                     </p>
@@ -752,7 +769,9 @@
                                         <option value="python">Python</option>
                                         <option value="js">JavaScript</option>
                                     </select>
-                                    <code id="allHouses-req-code"></code>
+                                    <pre>
+                                        <code id="allHouses-req-code">$ curl "https://www.anapioficeandfire.com/api/houses"</code>
+                                    </pre>
                                     <p>
                                         <strong>Example response:</strong>
                                     </p>
@@ -863,7 +882,9 @@
                                         <option value="python">Python</option>
                                         <option value="js">JavaScript</option>
                                     </select>
-                                    <code id="specificHouse-req-code"></code>
+                                    <pre>
+                                        <code id="specificHouse-req-code">$ curl "https://www.anapioficeandfire.com/api/houses/10"</code>
+                                    </pre>
                                     <p>
                                         <strong>Example response:</strong>
                                     </p>

--- a/src/AnApiOfIceAndFire/Views/Documentation/Index.cshtml
+++ b/src/AnApiOfIceAndFire/Views/Documentation/Index.cshtml
@@ -2,6 +2,73 @@
     ViewData["Title"] = "Documentation";
 }
 
+<script>
+
+    const jsonCodeData = {
+        "root": {
+            "curl": "$ \"https://www.anapioficeandfire.com/api\"",
+                "python": "this is the python code snippet",
+                    "js": "this is the js code snippet"
+        },
+        "allBooks": {
+            "curl": "$ \"https://www.anapioficeandfire.com/api/books\"",
+                "python": "this is the python code snippet",
+                    "js": "this is the js code snippet"
+        },
+        "specificBook": {
+            "curl": "$ curl \"https://www.anapioficeandfire.com/api/books/1\"",
+                "python": "",
+                    "js": ""
+        },
+        "allCharacters": {
+            "curl": "$ curl \"https://www.anapioficeandfire.com/api/characters\"",
+                "python": "",
+                    "js": ""
+        },
+        "specificCharacter": {
+            "curl": "$ curl \"https://www.anapioficeandfire.com/api/characters/823\"",
+                "python": "",
+                    "js": ""
+        },
+        "allHouses": {
+            "curl": "$ curl \"https://www.anapioficeandfire.com/api/houses\"",
+                "python": "",
+                    "js": ""
+        },
+        "specificHouse": {
+            "curl": "$ curl \"https://www.anapioficeandfire.com/api/houses/10\"",
+                "python": "",
+                    "js": ""
+        }
+    }
+
+    const setCodeSnippet = (e) => {
+        const dropDownElem = document.getElementById(e.target.id);
+        const lang = e.target.value;
+        const key = e.target.id.slice(0, e.target.id.indexOf("-"));
+        const codeElem = document.getElementById(key + "-req-code");
+        const codeSnippet = jsonCodeData[key][lang];
+        codeElem.innerHTML = codeSnippet;
+    }
+
+    const dropDownIds = [
+        "root",
+        "allBooks",
+        "specificBook",
+        "allCharacters",
+        "specificCharacter",
+        "allHouses",
+        "specificHouse",
+    ]
+
+    document.addEventListener("DOMContentLoaded", () => {
+        dropDownIds.forEach(id => {
+            const elem = document.getElementById(id + "-req-lang");
+            elem.addEventListener("change", setCodeSnippet);
+        });
+    })
+
+</script>
 
 <div id="layout-main-container" class="row">
     <div id="layout-content" class="large-12 columns">
@@ -123,7 +190,12 @@
                                 <h4>Root</h4>
                                 <p>The Root resource contains information about all available resources in the API.</p>
                                 <h5>Example request:</h5>
-                                <code>$ curl "https://www.anapioficeandfire.com/api"</code>
+                                <select id="root-req-lang">
+                                    <option value="curl">cURL</option>
+                                    <option value="python">Python</option>
+                                    <option value="js">JavaScript</option>
+                                </select>
+                                <code id="root-req-code"></code>
                                 <h5>Example response:</h5>
                                 <pre><code>{
     "books": "https://www.anapioficeandfire.com/api/books",
@@ -204,7 +276,12 @@
 
 
                                     <h5>List all books:</h5>
-                                    <code>$ curl "https://www.anapioficeandfire.com/api/books"</code>
+                                    <select id="allBooks-req-lang">
+                                        <option value="curl">cURL</option>
+                                        <option value="python">Python</option>
+                                        <option value="js">JavaScript</option>
+                                    </select>
+                                    <code id="allBooks-req-code"></code>
                                     <p>
                                         <strong>Example response:</strong>
                                     </p>
@@ -284,7 +361,12 @@
                                     </table>
 
                                     <h5>Get specific book</h5>
-                                    <code>$ curl "https://www.anapioficeandfire.com/api/books/1"</code>
+                                    <select id="specificBook-req-lang">
+                                        <option value="curl">cURL</option>
+                                        <option value="python">Python</option>
+                                        <option value="js">JavaScript</option>
+                                    </select>
+                                    <code id="specificBook-req-code"></code>
                                     <p>
                                         <strong>Example response:</strong>
                                     </p>
@@ -408,7 +490,12 @@
                                         </tbody>
                                     </table>
                                     <h5>List all characters:</h5>
-                                    <code>$ curl "https://www.anapioficeandfire.com/api/characters"</code>
+                                    <select id="allCharacters-req-lang">
+                                        <option value="curl">cURL</option>
+                                        <option value="python">Python</option>
+                                        <option value="js">JavaScript</option>
+                                    </select>
+                                    <code id="allCharacters-req-code"></code>
                                     <p>
                                         <strong>Example response:</strong>
                                     </p>
@@ -514,7 +601,12 @@
 
 
                                     <h5>Get specific character</h5>
-                                    <code>$ curl "https://www.anapioficeandfire.com/api/characters/823"</code>
+                                    <select id="specificCharacter-req-lang">
+                                        <option value="curl">cURL</option>
+                                        <option value="python">Python</option>
+                                        <option value="js">JavaScript</option>
+                                    </select>
+                                    <code id="specificCharacter-req-code"></code>
                                     <p>
                                         <strong>Example response:</strong>
                                     </p>
@@ -655,7 +747,12 @@
                                     </table>
 
                                     <h5>List all houses:</h5>
-                                    <code>$ curl "https://www.anapioficeandfire.com/api/houses"</code>
+                                    <select id="allHouses-req-lang">
+                                        <option value="curl">cURL</option>
+                                        <option value="python">Python</option>
+                                        <option value="js">JavaScript</option>
+                                    </select>
+                                    <code id="allHouses-req-code"></code>
                                     <p>
                                         <strong>Example response:</strong>
                                     </p>
@@ -761,7 +858,12 @@
 
 
                                     <h5>Get specific house</h5>
-                                    <code>$ curl "https://www.anapioficeandfire.com/api/houses/10"</code>
+                                    <select id="specificHouse-req-lang">
+                                        <option value="curl">cURL</option>
+                                        <option value="python">Python</option>
+                                        <option value="js">JavaScript</option>
+                                    </select>
+                                    <code id="specificHouse-req-code"></code>
                                     <p>
                                         <strong>Example response:</strong>
                                     </p>

--- a/src/AnApiOfIceAndFire/Views/Documentation/Index.cshtml
+++ b/src/AnApiOfIceAndFire/Views/Documentation/Index.cshtml
@@ -6,73 +6,81 @@
     code {
         display: block;
     }
+    .language-bash,
+    .language-python,
+    .language-js,
+    .language-json {
+        border: none;
+    }
 </style>
 
 <script>
 
-    const jsonCodeData = {
+    const get_python_code_snippet = (resourceName, resourceEndpoint) => {
+        return `import logging\nimport requests\n\nAN_API_OF_ICE_AND_FIRE_BASE_URL = "https://www.anapioficeandfire.com/api"\n\ndef get_${resourceName}():\n    url = f"{AN_API_OF_ICE_AND_FIRE_BASE_URL}/${resourceEndpoint}"\n    resp = requests.get(url)\n    if resp.status_code != 200:\n        logging.info(f"Error on request to {url}: {resp.text}")\n        return None\n    return resp.json()\n\n${resourceName} = get_${resourceName}()\nprint(${resourceName})`
+    }
+
+    const get_js_code_snippet = (resourceName, varName, resourceEndpoint) => {
+        return `const AN_API_OF_ICE_AND_FIRE_BASE_URL = "https://www.anapioficeandfire.com/api";\n\nconst get${resourceName} = async () => {\n  const url = \`\${AN_API_OF_ICE_AND_FIRE_BASE_URL}/${resourceEndpoint}\`;\n  const resp = await fetch(url);\n  if (resp.status !== 200) {\n    console.log(\`Error on request to \${url}: \${resp.statusText}\`);\n    return null;\n  };\n  return await resp.json();\n};\n\nconst ${varName} = get${resourceName}();\nconsole.log(${varName});`
+    }
+
+
+    const codeSnippets = {
         "root": {
-            "curl": "$ \"https://www.anapioficeandfire.com/api\"",
-            "python": "\nimport logging\nimport requests\nurl = \"https://www.anapioficeandfire.com/api\"\nresp = requests.get(url)\nif resp.status_code == 200:\n    data = resp.json()\nelse:\n    logging.info(f\"Error on request to {url}: {resp.text}\")\n ",
-            "js": "\nconst loadData = async () => {\n  const url = \"https://www.anapioficeandfire.com/api\";\n  const resp = await fetch(url);\n  if (resp.status === 200) {\n    const data = await resp.json();\n  } else {\n    console.log(\"Error on request. Error status code: \", resp.status)\n}\n ",
+            "bash": "$ curl \"https://www.anapioficeandfire.com/api\"",
+            "python": get_python_code_snippet("root", ""),
+            "js": get_js_code_snippet("Root", "root", ""),
         },
         "allBooks": {
-            "curl": "$ \"https://www.anapioficeandfire.com/api/books\"",
-            "python": "\nimport logging\nimport requests\nurl = \"https://www.anapioficeandfire.com/api/books\"\nresp = requests.get(url)\nif resp.status_code == 200:\n    data = resp.json()\nelse:\n    logging.info(f\"Error on request to {url}: {resp.text}\")\n ",
-            "js": "\nconst loadData = async () => {\n  const url = \"https://www.anapioficeandfire.com/api/books\";\n  const resp = await fetch(url);\n  if (resp.status === 200) {\n    const data = await resp.json();\n  } else {\n    console.log(\"Error on request. Error status code: \", resp.status)\n}\n "
+            "bash": "$ curl \"https://www.anapioficeandfire.com/api/books\"",
+            "python": get_python_code_snippet("books", "books"),
+            "js": get_js_code_snippet("Books", "books", "books"),
         },
         "specificBook": {
-            "curl": "$ curl \"https://www.anapioficeandfire.com/api/books/1\"",
-            "python": "\nimport logging\nimport requests\nurl = \"https://www.anapioficeandfire.com/api/books/1\"\nresp = requests.get(url)\nif resp.status_code == 200:\n    data = resp.json()\nelse:\n    logging.info(f\"Error on request to {url}: {resp.text}\")\n ",
-            "js": "\nconst loadData = async () => {\n  const url = \"https://www.anapioficeandfire.com/api/books/1\";\n  const resp = await fetch(url);\n  if (resp.status === 200) {\n    const data = await resp.json();\n  } else {\n    console.log(\"Error on request. Error status code: \", resp.status)\n}\n "
+            "bash": "$ curl \"https://www.anapioficeandfire.com/api/books/1\"",
+            "python": get_python_code_snippet("book", "books/1"),
+            "js": get_js_code_snippet("Book", "book", "books/1"),
         },
         "allCharacters": {
-            "curl": "$ curl \"https://www.anapioficeandfire.com/api/characters\"",
-            "python": "\nimport logging\nimport requests\nurl = \"https://www.anapioficeandfire.com/api/characters\"\nresp = requests.get(url)\nif resp.status_code == 200:\n    data = resp.json()\nelse:\n    logging.info(f\"Error on request to {url}: {resp.text}\")\n ",
-            "js": "\nconst loadData = async () => {\n  const url = \"https://www.anapioficeandfire.com/api/characters\";\n  const resp = await fetch(url);\n  if (resp.status === 200) {\n    const data = await resp.json();\n  } else {\n    console.log(\"Error on request. Error status code: \", resp.status)\n}\n "
+            "bash": "$ curl \"https://www.anapioficeandfire.com/api/characters\"",
+            "python": get_python_code_snippet("characters", "characters"),
+            "js": get_js_code_snippet("Characters", "characters", "characters"),
         },
         "specificCharacter": {
-            "curl": "$ curl \"https://www.anapioficeandfire.com/api/characters/823\"",
-            "python": "\nimport logging\nimport requests\nurl = \"https://www.anapioficeandfire.com/api/characters/823\"\nresp = requests.get(url)\nif resp.status_code == 200:\n    data = resp.json()\nelse:\n    logging.info(f\"Error on request to {url}: {resp.text}\")\n ",
-            "js": "\nconst loadData = async () => {\n  const url = \"https://www.anapioficeandfire.com/api/characters/823\";\n  const resp = await fetch(url);\n  if (resp.status === 200) {\n    const data = await resp.json();\n  } else {\n    console.log(\"Error on request. Error status code: \", resp.status)\n}\n "
+            "bash": "$ curl \"https://www.anapioficeandfire.com/api/characters/823\"",
+            "python": get_python_code_snippet("character", "characters/823"),
+            "js": get_js_code_snippet("Character", "character", "characters/823"),
         },
         "allHouses": {
-            "curl": "$ curl \"https://www.anapioficeandfire.com/api/houses\"",
-            "python": "\nimport logging\nimport requests\nurl = \"https://www.anapioficeandfire.com/api/houses\"\nresp = requests.get(url)\nif resp.status_code == 200:\n    data = resp.json()\nelse:\n    logging.info(f\"Error on request to {url}: {resp.text}\")\n ",
-            "js": "\nconst loadData = async () => {\n  const url = \"https://www.anapioficeandfire.com/api/houses\";\n  const resp = await fetch(url);\n  if (resp.status === 200) {\n    const data = await resp.json();\n  } else {\n    console.log(\"Error on request. Error status code: \", resp.status)\n}\n "
+            "bash": "$ curl \"https://www.anapioficeandfire.com/api/houses\"",
+            "python": get_python_code_snippet("houses", "houses"),
+            "js": get_js_code_snippet("Houses", "houses", "houses"),
         },
         "specificHouse": {
-            "curl": "$ curl \"https://www.anapioficeandfire.com/api/houses/10\"",
-            "python": "\nimport logging\nimport requests\nurl = \"https://www.anapioficeandfire.com/api/houses/10\"\nresp = requests.get(url)\nif resp.status_code == 200:\n    data = resp.json()\nelse:\n    logging.info(f\"Error on request to {url}: {resp.text}\")\n ",
-            "js": "\nconst loadData = async () => {\n  const url = \"https://www.anapioficeandfire.com/api/houses/10\";\n  const resp = await fetch(url);\n  if (resp.status === 200) {\n    const data = await resp.json();\n  } else {\n    console.log(\"Error on request. Error status code: \", resp.status)\n}\n "
+            "bash": "$ curl \"https://www.anapioficeandfire.com/api/houses/10\"",
+            "python": get_python_code_snippet("house", "houses/10"),
+            "js": get_js_code_snippet("House", "house", "houses/10"),
         }
     }
 
-    const elemIdRoots = [
-        "root",
-        "allBooks",
-        "specificBook",
-        "allCharacters",
-        "specificCharacter",
-        "allHouses",
-        "specificHouse",
-    ]
-
-    const setCodeSnippets = (e) => {
-        elemIdRoots.forEach(id => {
-            const codeElem = document.getElementById(id + "-req-code");
-            const codeSnippet = jsonCodeData[id][e.target.value];
-            codeElem.innerText = codeSnippet;
-            const dropDownElem = document.getElementById(id + "-req-lang");
+    const setCodeSnippetsText = (e) => {
+        Object.keys(codeSnippets).forEach(k => {
+            const codeElem = document.getElementById(`${k}-code`);
+            const codeSnippet = codeSnippets[k][e.target.value];
+            codeElem.innerHTML = codeSnippet;
+            codeElem.className = `language-${e.target.value}`
+            const dropDownElem = document.getElementById(`${k}-lang`);
             dropDownElem.value = e.target.value;
-        })
+        });
+        Prism.highlightAll();
     }
 
     document.addEventListener("DOMContentLoaded", () => {
-        elemIdRoots.forEach(id => {
-            const elem = document.getElementById(id + "-req-lang");
-            elem.addEventListener("change", setCodeSnippets);
+        Object.keys(codeSnippets).forEach(k => {
+            const elem = document.getElementById(`${k}-lang`);
+            elem.addEventListener("change", setCodeSnippetsText);
         });
+        Prism.highlightAll();
     })
 
 </script>
@@ -127,7 +135,7 @@
                                     You specify which page you want to access with the <code>?page</code> parameter, if you don't provide the <code>?page</code> parameter the first page will be returned. You can also specify the size of the page with the <code>?pageSize</code> parameter, if you don't provide the <code>?pageSize</code> parameter the default size of 10 will be used.
                                 </p>
                                 <p>Let's make a request for the first page of characters with a page size of 10. Since we're only interested in the pagination information we provide the -I parameter to say that we only care about the headers.</p>
-
+                                
                                 <code>$ curl -I "https://www.anapioficeandfire.com/api/characters?page=1&pageSize=10"</code>
                                 <p>
                                     <strong>Here's the link header in the response:</strong>
@@ -197,16 +205,16 @@
                                 <h4>Root</h4>
                                 <p>The Root resource contains information about all available resources in the API.</p>
                                 <h5>Example request:</h5>
-                                <select id="root-req-lang">
-                                    <option value="curl">cURL</option>
+                                <select id="root-lang">
+                                    <option value="bash">cURL</option>
                                     <option value="python">Python</option>
                                     <option value="js">JavaScript</option>
                                 </select>
                                 <pre>
-                                    <code id="root-req-code">$ curl "https://www.anapioficeandfire.com/api"</code>
+                                    <code class="language-bash line-numbers" id="root-code">$ curl "https://www.anapioficeandfire.com/api"</code>
                                 </pre>
                                 <h5>Example response:</h5>
-                                <pre><code>{
+                                <pre><code class="language-json line-numbers">{
     "books": "https://www.anapioficeandfire.com/api/books",
     "characters": "https://www.anapioficeandfire.com/api/characters",
     "houses": "https://www.anapioficeandfire.com/api/houses"
@@ -285,18 +293,18 @@
 
 
                                     <h5>List all books:</h5>
-                                    <select id="allBooks-req-lang">
-                                        <option value="curl">cURL</option>
+                                    <select id="allBooks-lang">
+                                        <option value="bash">cURL</option>
                                         <option value="python">Python</option>
                                         <option value="js">JavaScript</option>
                                     </select>
                                     <pre>
-                                        <code id="allBooks-req-code">$ curl "https://www.anapioficeandfire.com/api/books"</code>
+                                    <code class="language-bash line-numbers" id="allBooks-code">$ curl "https://www.anapioficeandfire.com/api/books"</code>
                                     </pre>
                                     <p>
                                         <strong>Example response:</strong>
                                     </p>
-                                    <pre><code>[
+                                    <pre><code class="language-json line-numbers">[
   {
     "url": "https://www.anapioficeandfire.com/api/books/1",
     "name": "A Game of Thrones",
@@ -372,18 +380,18 @@
                                     </table>
 
                                     <h5>Get specific book</h5>
-                                    <select id="specificBook-req-lang">
-                                        <option value="curl">cURL</option>
+                                    <select id="specificBook-lang">
+                                        <option value="bash">cURL</option>
                                         <option value="python">Python</option>
                                         <option value="js">JavaScript</option>
                                     </select>
                                     <pre>
-                                        <code id="specificBook-req-code">$ curl "https://www.anapioficeandfire.com/api/books/1"</code>
+                                        <code class="language-bash line-numbers" id="specificBook-code">$ curl "https://www.anapioficeandfire.com/api/books/1"</code>
                                     </pre>
                                     <p>
                                         <strong>Example response:</strong>
                                     </p>
-                                    <pre><code>{
+                                    <pre><code class="language-json line-numbers">{
   "url": "https://www.anapioficeandfire.com/api/books/1",
   "name": "A Game of Thrones",
   "isbn": "978-0553103540",
@@ -503,18 +511,18 @@
                                         </tbody>
                                     </table>
                                     <h5>List all characters:</h5>
-                                    <select id="allCharacters-req-lang">
-                                        <option value="curl">cURL</option>
+                                    <select id="allCharacters-lang">
+                                        <option value="bash">cURL</option>
                                         <option value="python">Python</option>
                                         <option value="js">JavaScript</option>
                                     </select>
                                     <pre>
-                                        <code id="allCharacters-req-code">$ curl "https://www.anapioficeandfire.com/api/characters"</code>
+                                        <code class="language-bash line-numbers" id="allCharacters-code">$ curl "https://www.anapioficeandfire.com/api/characters"</code>
                                     </pre>
                                     <p>
                                         <strong>Example response:</strong>
                                     </p>
-                                    <pre><code>[
+                                    <pre><code class="language-json line-numbers">[
   {
     "url": "https://www.anapioficeandfire.com/api/characters/1",
     "name": "",
@@ -616,18 +624,18 @@
 
 
                                     <h5>Get specific character</h5>
-                                    <select id="specificCharacter-req-lang">
-                                        <option value="curl">cURL</option>
+                                    <select id="specificCharacter-lang">
+                                        <option value="bash">cURL</option>
                                         <option value="python">Python</option>
                                         <option value="js">JavaScript</option>
                                     </select>
                                     <pre>
-                                        <code id="specificCharacter-req-code">$ curl "https://www.anapioficeandfire.com/api/characters/823"</code>
+                                        <code class="language-bash line-numbers" id="specificCharacter-code">$ curl "https://www.anapioficeandfire.com/api/characters/823"</code>
                                     </pre>
                                     <p>
                                         <strong>Example response:</strong>
                                     </p>
-                                    <pre><code>{
+                                    <pre><code class="language-json line-numbers">{
   "url": "https://www.anapioficeandfire.com/api/characters/823",
   "name": "Petyr Baelish",
   "culture": "Valemen",
@@ -764,18 +772,18 @@
                                     </table>
 
                                     <h5>List all houses:</h5>
-                                    <select id="allHouses-req-lang">
-                                        <option value="curl">cURL</option>
+                                    <select id="allHouses-lang">
+                                        <option value="bash">cURL</option>
                                         <option value="python">Python</option>
                                         <option value="js">JavaScript</option>
                                     </select>
                                     <pre>
-                                        <code id="allHouses-req-code">$ curl "https://www.anapioficeandfire.com/api/houses"</code>
+                                        <code class="language-bash line-numbers" id="allHouses-code">$ curl "https://www.anapioficeandfire.com/api/houses"</code>
                                     </pre>
                                     <p>
                                         <strong>Example response:</strong>
                                     </p>
-                                    <pre><code>[
+                                    <pre><code class="language-json line-numbers">[
   {
     "url": "https://www.anapioficeandfire.com/api/houses/1",
     "name": "House Algood",
@@ -877,18 +885,18 @@
 
 
                                     <h5>Get specific house</h5>
-                                    <select id="specificHouse-req-lang">
-                                        <option value="curl">cURL</option>
+                                    <select id="specificHouse-lang">
+                                        <option value="bash">cURL</option>
                                         <option value="python">Python</option>
                                         <option value="js">JavaScript</option>
                                     </select>
                                     <pre>
-                                        <code id="specificHouse-req-code">$ curl "https://www.anapioficeandfire.com/api/houses/10"</code>
+                                        <code class="language-bash line-numbers" id="specificHouse-code">$ curl "https://www.anapioficeandfire.com/api/houses/10"</code>
                                     </pre>
                                     <p>
                                         <strong>Example response:</strong>
                                     </p>
-                                    <pre><code>{
+                                    <pre><code class="language-json line-numbers">{
   "url": "https://www.anapioficeandfire.com/api/houses/10",
   "name": "House Baelish of Harrenhal",
   "region": "The Riverlands",

--- a/src/AnApiOfIceAndFire/Views/Documentation/Index.cshtml
+++ b/src/AnApiOfIceAndFire/Views/Documentation/Index.cshtml
@@ -14,75 +14,7 @@
     }
 </style>
 
-<script>
-
-    const get_python_code_snippet = (resourceName, resourceEndpoint) => {
-        return `import logging\nimport requests\n\nAN_API_OF_ICE_AND_FIRE_BASE_URL = "https://www.anapioficeandfire.com/api"\n\ndef get_${resourceName}():\n    url = f"{AN_API_OF_ICE_AND_FIRE_BASE_URL}/${resourceEndpoint}"\n    resp = requests.get(url)\n    if resp.status_code != 200:\n        logging.info(f"Error on request to {url}: {resp.text}")\n        return None\n    return resp.json()\n\n${resourceName} = get_${resourceName}()\nprint(${resourceName})`
-    }
-
-    const get_js_code_snippet = (resourceName, varName, resourceEndpoint) => {
-        return `const AN_API_OF_ICE_AND_FIRE_BASE_URL = "https://www.anapioficeandfire.com/api";\n\nconst get${resourceName} = async () => {\n  const url = \`\${AN_API_OF_ICE_AND_FIRE_BASE_URL}/${resourceEndpoint}\`;\n  const resp = await fetch(url);\n  if (resp.status !== 200) {\n    console.log(\`Error on request to \${url}: \${resp.statusText}\`);\n    return null;\n  };\n  return await resp.json();\n};\n\nconst ${varName} = get${resourceName}();\nconsole.log(${varName});`
-    }
-
-
-    const codeSnippets = {
-        "root": {
-            "bash": "$ curl \"https://www.anapioficeandfire.com/api\"",
-            "python": get_python_code_snippet("root", ""),
-            "js": get_js_code_snippet("Root", "root", ""),
-        },
-        "allBooks": {
-            "bash": "$ curl \"https://www.anapioficeandfire.com/api/books\"",
-            "python": get_python_code_snippet("books", "books"),
-            "js": get_js_code_snippet("Books", "books", "books"),
-        },
-        "specificBook": {
-            "bash": "$ curl \"https://www.anapioficeandfire.com/api/books/1\"",
-            "python": get_python_code_snippet("book", "books/1"),
-            "js": get_js_code_snippet("Book", "book", "books/1"),
-        },
-        "allCharacters": {
-            "bash": "$ curl \"https://www.anapioficeandfire.com/api/characters\"",
-            "python": get_python_code_snippet("characters", "characters"),
-            "js": get_js_code_snippet("Characters", "characters", "characters"),
-        },
-        "specificCharacter": {
-            "bash": "$ curl \"https://www.anapioficeandfire.com/api/characters/823\"",
-            "python": get_python_code_snippet("character", "characters/823"),
-            "js": get_js_code_snippet("Character", "character", "characters/823"),
-        },
-        "allHouses": {
-            "bash": "$ curl \"https://www.anapioficeandfire.com/api/houses\"",
-            "python": get_python_code_snippet("houses", "houses"),
-            "js": get_js_code_snippet("Houses", "houses", "houses"),
-        },
-        "specificHouse": {
-            "bash": "$ curl \"https://www.anapioficeandfire.com/api/houses/10\"",
-            "python": get_python_code_snippet("house", "houses/10"),
-            "js": get_js_code_snippet("House", "house", "houses/10"),
-        }
-    }
-
-    const setCodeSnippetsText = (e) => {
-        Object.keys(codeSnippets).forEach(k => {
-            const codeElem = document.getElementById(`${k}-code`);
-            const codeSnippet = codeSnippets[k][e.target.value];
-            codeElem.innerHTML = codeSnippet;
-            codeElem.className = `language-${e.target.value}`
-            const dropDownElem = document.getElementById(`${k}-lang`);
-            dropDownElem.value = e.target.value;
-        });
-        Prism.highlightAll();
-    }
-
-    document.addEventListener("DOMContentLoaded", () => {
-        Object.keys(codeSnippets).forEach(k => {
-            const elem = document.getElementById(`${k}-lang`);
-            elem.addEventListener("change", setCodeSnippetsText);
-        });
-        Prism.highlightAll();
-    })
-
+<script src="./script.js">
 </script>
 
 <div id="layout-main-container" class="row">
@@ -461,7 +393,7 @@
                                             <tr>
                                                 <td>titles</td>
                                                 <td>array of strings</td>
-                                                <td>TThe titles that this character holds.</td>
+                                                <td>The titles that this character holds.</td>
                                             </tr>
                                             <tr>
                                                 <td>aliases</td>

--- a/src/AnApiOfIceAndFire/Views/Shared/_Layout.cshtml
+++ b/src/AnApiOfIceAndFire/Views/Shared/_Layout.cshtml
@@ -9,12 +9,22 @@
     <environment names="Development">
         <link rel="stylesheet" href="~/css/site.css" />
         <link rel="stylesheet" href="~/lib/font-awesome/css/font-awesome.min.css" />
+        <link href="https://cdn.jsdelivr.net/npm/prismjs@1.29.0/themes/prism.css" rel="stylesheet" />
+        <link href="https://cdn.jsdelivr.net/npm/prismjs@1.29.0/plugins/line-numbers/prism-line-numbers.min.css" rel="stylesheet" />
+        <script src="https://cdn.jsdelivr.net/npm/prismjs@1.29.0/components/prism-core.min.js"></script>
+        <script src="https://cdn.jsdelivr.net/npm/prismjs@1.29.0/plugins/autoloader/prism-autoloader.min.js"></script>
+        <script src="https://cdn.jsdelivr.net/npm/prismjs@1.29.0/plugins/line-numbers/prism-line-numbers.min.js"></script>
     </environment>
     <environment names="Staging,Production">
         <link rel="stylesheet" href="~/css/site.min.css" asp-append-version="true" />
         <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css"
               asp-fallback-href="~/lib/font-awesome/css/font-awesome.min.css"
               asp-fallback-test-class="sr-only" asp-fallback-test-property="position" asp-fallback-test-value="absolute" />
+        <link href="https://cdn.jsdelivr.net/npm/prismjs@1.29.0/themes/prism.css" rel="stylesheet" />
+        <link href="https://cdn.jsdelivr.net/npm/prismjs@1.29.0/plugins/line-numbers/prism-line-numbers.min.css" rel="stylesheet" />
+        <script src="https://cdn.jsdelivr.net/npm/prismjs@1.29.0/components/prism-core.min.js"></script>
+        <script src="https://cdn.jsdelivr.net/npm/prismjs@1.29.0/plugins/autoloader/prism-autoloader.min.js"></script>
+        <script src="https://cdn.jsdelivr.net/npm/prismjs@1.29.0/plugins/line-numbers/prism-line-numbers.min.js"></script>
     </environment>
 </head>
 <body>

--- a/src/AnApiOfIceAndFire/wwwroot/script.js
+++ b/src/AnApiOfIceAndFire/wwwroot/script.js
@@ -1,0 +1,83 @@
+// contains functionality for rendering highlighted code examples for each resource in Documentation/Index.cshtml
+
+const maybeAddForwardSlash = (resourceEndpoint) => {
+    return resourceEndpoint ? `/${resourceEndpoint}` : resourceEndpoint;
+}
+
+const get_curl_code_snippet = (resourceEndpoint) => {
+    resourceEndpoint = maybeAddForwardSlash(resourceEndpoint);
+    return `$ curl "https://www.anapioficeandfire.com/api${resourceEndpoint}"`;
+}
+
+const get_python_code_snippet = (resourceName, resourceEndpoint) => {
+    resourceEndpoint = maybeAddForwardSlash(resourceEndpoint);
+    return `import logging\nimport requests\n\nAN_API_OF_ICE_AND_FIRE_BASE_URL = "https://www.anapioficeandfire.com/api"\n\ndef get_${resourceName}():\n    url = f"{AN_API_OF_ICE_AND_FIRE_BASE_URL}${resourceEndpoint}"\n    resp = requests.get(url)\n    if resp.status_code != 200:\n        logging.info(f"Error on request to {url}: {resp.text}")\n        return None\n    return resp.json()\n\n${resourceName} = get_${resourceName}()\nprint(${resourceName})`;
+}
+
+const get_js_code_snippet = (resourceName, varName, resourceEndpoint) => {
+    resourceEndpoint = maybeAddForwardSlash(resourceEndpoint);
+    return `const AN_API_OF_ICE_AND_FIRE_BASE_URL = "https://www.anapioficeandfire.com/api";\n\nconst get${resourceName} = async () => {\n  const url = \`\${AN_API_OF_ICE_AND_FIRE_BASE_URL}${resourceEndpoint}\`;\n  const resp = await fetch(url);\n  if (resp.status !== 200) {\n    console.log(\`Error on request to \${url}: \${resp.statusText}\`);\n    return null;\n  };\n  const data = await resp.json();\n  return data;\n};\n\nget${resourceName}().then(${varName} => {\n  console.log(${varName});\n});`;
+}
+
+
+const codeSnippets = {
+    "root": {
+        "bash": get_curl_code_snippet(""),
+        "python": get_python_code_snippet("root", ""),
+        "js": get_js_code_snippet("Root", "root", ""),
+    },
+    "allBooks": {
+        "bash": get_curl_code_snippet("books"),
+        "python": get_python_code_snippet("books", "books"),
+        "js": get_js_code_snippet("Books", "books", "books"),
+    },
+    "specificBook": {
+        "bash": get_curl_code_snippet("books/1"),
+        "python": get_python_code_snippet("book", "books/1"),
+        "js": get_js_code_snippet("Book", "book", "books/1"),
+    },
+    "allCharacters": {
+        "bash": get_curl_code_snippet("characters"),
+        "python": get_python_code_snippet("characters", "characters"),
+        "js": get_js_code_snippet("Characters", "characters", "characters"),
+    },
+    "specificCharacter": {
+        "bash": get_curl_code_snippet("characters/823"),
+        "python": get_python_code_snippet("character", "characters/823"),
+        "js": get_js_code_snippet("Character", "character", "characters/823"),
+    },
+    "allHouses": {
+        "bash": get_curl_code_snippet("house"),
+        "python": get_python_code_snippet("houses", "houses"),
+        "js": get_js_code_snippet("Houses", "houses", "houses"),
+    },
+    "specificHouse": {
+        "bash": get_curl_code_snippet("houses/10"),
+        "python": get_python_code_snippet("house", "houses/10"),
+        "js": get_js_code_snippet("House", "house", "houses/10"),
+    }
+}
+
+const setCodeSnippetsText = (e) => {
+    Object.keys(codeSnippets).forEach(k => {
+        const codeElem = document.getElementById(`${k}-code`);
+        const codeSnippet = codeSnippets[k][e.target.value];
+        codeElem.innerHTML = codeSnippet;
+        codeElem.className = `language-${e.target.value}`
+        const dropDownElem = document.getElementById(`${k}-lang`);
+        dropDownElem.value = e.target.value;
+    });
+    Prism.highlightAll();
+}
+
+const addOnChangeListener = () => {
+    document.addEventListener("DOMContentLoaded", () => {
+        Object.keys(codeSnippets).forEach(k => {
+            const elem = document.getElementById(`${k}-lang`);
+            elem.addEventListener("change", setCodeSnippetsText);
+        });
+        Prism.highlightAll();
+    });
+}
+
+addOnChangeListener();

--- a/src/AnApiOfIceAndFire/wwwroot/script.js
+++ b/src/AnApiOfIceAndFire/wwwroot/script.js
@@ -1,5 +1,4 @@
 // contains functionality for rendering highlighted code examples for each resource in Documentation/Index.cshtml
-
 const maybeAddForwardSlash = (resourceEndpoint) => {
     return resourceEndpoint ? `/${resourceEndpoint}` : resourceEndpoint;
 }

--- a/tests/AnApiOfIceAndFire.Tests/Views/chutzpah.json
+++ b/tests/AnApiOfIceAndFire.Tests/Views/chutzpah.json
@@ -1,0 +1,15 @@
+{
+  "Framework": "jasmine",
+  "TestHarnessLocationMode": "SettingsFileAdjacent",
+  "References": [
+    { "Path": "../../../src/AnApiOfIceAndFire/wwwroot/script.js" },
+    { "Path": "https://cdn.jsdelivr.net/npm/prismjs@1.29.0/components/prism-core.min.js" }
+  ],
+  "Tests": [
+    { "Path": "test.js" }
+  ],
+  "Engine": "JSDom",
+  "Server": {
+    "Enabled": true
+  }
+}

--- a/tests/AnApiOfIceAndFire.Tests/Views/test.js
+++ b/tests/AnApiOfIceAndFire.Tests/Views/test.js
@@ -1,0 +1,922 @@
+﻿﻿/// <reference path="../../../src/AnApiOfIceAndFire/wwwroot/script.js" />
+
+// TODO: figure out how to use JSDOM in this file to test the setCodeSnippetsText and addOnChangeListener functions
+
+
+describe("test maybeAddForwardSlash function", function () {
+    it("should add a forward slash when passed a non-empty string", function () {
+        const s = maybeAddForwardSlash("books");
+        expect(s).toEqual("/books");
+    });
+
+    it("should return an empty string when passed a string", function () {
+        const s = maybeAddForwardSlash("");
+        expect(s).toEqual("");
+    });
+});
+
+describe("test code snippet functions", function () {
+    it("should return snippet with valid cURL request", function () {
+        const snippet1 = `$ curl "https://www.anapioficeandfire.com/api/books"`
+        const snippet2 = get_curl_code_snippet("books");
+        expect(snippet1).toEqual(snippet2);
+    });
+
+    it("should return snippet with valid python code", function () {
+        const snippet = get_python_code_snippet("books", "books");
+        expect(snippet).toEqual(pythonCodeSnippetBooksResource);
+    });
+
+    it("should return snippet with valid JavaScript code", function () {
+        const snippet1 = `const AN_API_OF_ICE_AND_FIRE_BASE_URL = "https://www.anapioficeandfire.com/api";\n\nconst getBooks = async () => {\n  const url = \`\${AN_API_OF_ICE_AND_FIRE_BASE_URL}/books\`;\n  const resp = await fetch(url);\n  if (resp.status !== 200) {\n    console.log(\`Error on request to \${url}: \${resp.statusText}\`);\n    return null;\n  };\n  const data = await resp.json();\n  return data;\n};\n\ngetBooks().then(books => {\n  console.log(books);\n});`;
+        const snippet2 = get_js_code_snippet("Books", "books", "books")
+        expect(snippet1).toEqual(snippet2);
+    });
+})
+
+
+//describe("", function () {
+
+//    beforeEach(function () {
+//        document.body.innerHTML = documentationPageHTMLStr;
+//    });
+
+//    it("should set element's innerHTML to code snippets", function () {
+//        setCodeSnippetsText(mockEvent);
+//        const elem = document.getElementById("books-code");
+//        expect(elem.innerHTML).toEqual(pythonCodeSnippetBooksResource);
+//    });
+
+//    it("should set element's class name to language-python", function () {
+//        setCodeSnippetsText(mockEvent);
+//        const elem = document.getElementById("books-code");
+//        expect(elem.className).toEqual("language-python");
+//    });
+
+//    it("should dropdown language selection's value to python", function () {
+//        setCodeSnippetsText(mockEvent);
+//        const elem = document.getElementById("books-lang");
+//        expect(elem.value).toEqual(mockEvent.target.value);
+//    });
+//})
+
+
+const pythonCodeSnippetBooksResource = `import logging\nimport requests\n\nAN_API_OF_ICE_AND_FIRE_BASE_URL = "https://www.anapioficeandfire.com/api"\n\ndef get_books():\n    url = f"{AN_API_OF_ICE_AND_FIRE_BASE_URL}/books"\n    resp = requests.get(url)\n    if resp.status_code != 200:\n        logging.info(f"Error on request to {url}: {resp.text}")\n        return None\n    return resp.json()\n\nbooks = get_books()\nprint(books)`;
+
+//const mockEvent = { target: { value: "python" } };
+
+//const documentationPageHTMLStr = `<div id="layout-main - container" class="row">
+//    < div id = "layout-content" class="large-12 columns" >
+//        <section id="content" class="row">
+//            <div class="large-12 columns">
+//                <article>
+//                    <header id="page-header">
+//                        <h1 class="page-title">Documentation</h1>
+//                    </header>
+//                    <div class="row">
+//                        <div class="small-12 column show-for-small-only">
+//                            @Html.Partial("_Menu")
+//                        </div>
+//                        <div class="small-12 medium-8 column">
+//                            <hr />
+//                            <div>
+//                                <a name="intro"></a>
+//                                <h4>Introduction</h4>
+//                                <p>This documentation will help you familiarise yourself with the API and how to consume the different resources that are available. The documentation provides all information needed to get started and it also has educational examples for all resources.</p>
+//                                <p>
+//                                    If you're interested in using a native implementation, please take a look at the <strong>Libraries</strong> section.
+//                                </p>
+//                            </div>
+//                            <div>
+//                                <a name="current-version"></a>
+//                                <h4>Current Version</h4>
+//                                <p>The current version of the API is 1.</p>
+//                            </div>
+//                            <div>
+//                                <a name="authentication"></a>
+//                                <h4>Authentication</h4>
+//                                <p>An API of Ice And Fire is an open API. This means that no authentication is required to query the API for data. Since no authentication is required, there is only support for GET-ing data.</p>
+//                            </div>
+//                            <div>
+//                                <a name="pagination"></a>
+//                                <h4>Pagination</h4>
+//                                <p>An API of Ice And Fire provides a lot of data about the world of Westeros. To prevent our servers from getting cranky, the API will automatically paginate the responses. You will learn how to create requests with pagination parameters and consume the response.</p>
+
+//                                <h5>Things worth noting:</h5>
+
+//                                <ol>
+//                                    <li>Information about the pagination is included in <a href="https://tools.ietf.org/html/rfc5988">the Link header</a></li>
+//                                    <li>Page numbering is 1-based</li>
+//                                    <li>You can specify how many items you want to receive per page, the maximum is 50</li>
+//                                </ol>
+
+//                                <h5>Constructing a request with pagination</h5>
+//                                <p>
+//                                    You specify which page you want to access with the <code>?page</code> parameter, if you don't provide the <code>?page</code> parameter the first page will be returned. You can also specify the size of the page with the <code>?pageSize</code> parameter, if you don't provide the <code>?pageSize</code> parameter the default size of 10 will be used.
+//                                </p>
+//                                <p>Let's make a request for the first page of characters with a page size of 10. Since we're only interested in the pagination information we provide the -I parameter to say that we only care about the headers.</p>
+
+//                                <code>$ curl -I "https://www.anapioficeandfire.com/api/characters?page=1&pageSize=10"</code>
+//                                <p>
+//                                    <strong>Here's the link header in the response:</strong>
+//                                </p>
+//                                <code>
+
+//                                    Link: &lt;https://www.anapioficeandfire.com/api/characters?page=2&amp;pageSize=10&gt;; rel="next",
+//                                    &lt;https://www.anapioficeandfire.com/api/characters?page=1&amp;pageSize=10&gt;; rel="first",
+//                                    &lt;https://www.anapioficeandfire.com/api/characters?page=214&amp;pageSize=10&gt;; rel="last"
+//                                </code>
+//                                <p></p>
+//                                <h5>Possible link types:</h5>
+//                                <ul>
+//                                    <li>
+//                                        <strong>next</strong> - Next page of results
+//                                    </li>
+//                                    <li>
+//                                        <strong>prev</strong> - Previous page of results
+//                                    </li>
+//                                    <li>
+//                                        <strong>first</strong> - First page of results
+//                                    </li>
+//                                    <li>
+//                                        <strong>last</strong> - Last page of results
+//                                    </li>
+//                                </ul>
+
+//                                <p>These links can then be used to navigate to other pages of results.</p>
+//                            </div>
+//                            <div>
+//                                <a name="rate-limiting"></a>
+//                                <h4>Rate Limiting</h4>
+//                                <p>To prevent malicious usage of our API we've a limit on the number of requests a given IP address can make to the API. This limit is set to 20000 requests per day. There should be no reason for hitting the limit if you implement proper caching strategies in your client. If you happen to hit the limit you'll receive a 403 Forbidden on all your requests for the remainder of the 24 hour time period.</p>
+//                            </div>
+//                            <div>
+//                                <a name="caching"></a>
+//                                <h4>Caching</h4>
+//                                <p>Apart from the standard cache headers such as max-age we also provide a few different ways to ease the load on our servers and your client. Each API response includes the ETag-header and the Last-Modified header. These headers can be used to ask our server if the data has changed or not. If the data has not changed you will receive an empty response body with a 304 Not Modified. If the data has changed you will receive a 200 with the updated data.</p>
+
+//                                <h5>To use the ETag, include the following header in your request:</h5>
+//                                <code>If-None-Match: "your_etag_here"</code>
+//                                <p></p>
+//                                <h5>To use Last-Modified, include the following header in your request:</h5>
+//                                <code>If-Modified-Since: "date_here"</code>
+//                                <p></p>
+//                            </div>
+//                            <div>
+//                                <a name="versioning"></a>
+//                                <h4>Versioning</h4>
+//                                <p>Custom media types are used in An API of Ice And Fire to let consumers choose which version of the data they wish to receive. This is done by adding the following type to the Accept header when you make a request. Note that media types are specific to resources, this allows them to change independently from each other.</p>
+
+//                                <p>
+//                                    <strong>Important:</strong> If a version is not specified in the request the default version will be used. The default version may change in the future and can thus break the consumer's application. Make sure to always request a specific version in the <code>Accept</code> header as shown in the example below.
+//                                </p>
+
+//                                <h5>You specify a version like so:</h5>
+//                                <code>application/vnd.anapioficeandfire+json; version=1</code>
+//                                <p></p>
+//                            </div>
+
+
+
+//                            <h3>Resources</h3>
+//                            <hr />
+//                            <div>
+//                                <a name="root"></a>
+//                                <h4>Root</h4>
+//                                <p>The Root resource contains information about all available resources in the API.</p>
+//                                <h5>Example request:</h5>
+//                                <select id="root-lang">
+//                                    <option value="bash">cURL</option>
+//                                    <option value="python">Python</option>
+//                                    <option value="js">JavaScript</option>
+//                                </select>
+//                                <pre>
+//                                    <code class="language-bash line-numbers" id="root-code">$ curl "https://www.anapioficeandfire.com/api"</code>
+//                                </pre>
+//                                <h5>Example response:</h5>
+//                                <pre><code class="language-json line-numbers">{
+//                                    "books": "https://www.anapioficeandfire.com/api/books",
+//                                    "characters": "https://www.anapioficeandfire.com/api/characters",
+//                                    "houses": "https://www.anapioficeandfire.com/api/houses"
+// }
+//                                </code></pre>
+//                                <p></p>
+//                                <div>
+//                                    <a name="books"></a>
+//                                    <h4>Books</h4>
+//                                    <table>
+//                                        <thead>
+//                                            <tr>
+//                                                <th>Name</th>
+//                                                <th>Type</th>
+//                                                <th>Description</th>
+//                                            </tr>
+//                                        </thead>
+//                                        <tbody>
+//                                            <tr>
+//                                                <td>url</td>
+//                                                <td>string</td>
+//                                                <td>The hypermedia URL of this resource</td>
+//                                            </tr>
+//                                            <tr>
+//                                                <td>name</td>
+//                                                <td>string</td>
+//                                                <td>The name of this book</td>
+//                                            </tr>
+//                                            <tr>
+//                                                <td>isbn</td>
+//                                                <td>string</td>
+//                                                <td>The International Standard Book Number (ISBN-13) that uniquely identifies this book.</td>
+//                                            </tr>
+//                                            <tr>
+//                                                <td>authors</td>
+//                                                <td>array of strings</td>
+//                                                <td>An array of names of the authors that wrote this book.</td>
+//                                            </tr>
+//                                            <tr>
+//                                                <td>numberOfPages</td>
+//                                                <td>integer</td>
+//                                                <td>The number of pages in this book.</td>
+//                                            </tr>
+//                                            <tr>
+//                                                <td>publiser</td>
+//                                                <td>string</td>
+//                                                <td>The company that published this book.</td>
+//                                            </tr>
+//                                            <tr>
+//                                                <td>country</td>
+//                                                <td>string</td>
+//                                                <td>The country that this book was published in</td>
+//                                            </tr>
+//                                            <tr>
+//                                                <td>mediaType</td>
+//                                                <td>string</td>
+//                                                <td>The type of media this book was released in.</td>
+//                                            </tr>
+//                                            <tr>
+//                                                <td>released</td>
+//                                                <td>date</td>
+//                                                <td>The date (ISO 8601) when this book was released.</td>
+//                                            </tr>
+//                                            <tr>
+//                                                <td>characters</td>
+//                                                <td>array of strings</td>
+//                                                <td>An array of Character resource URLs that has been in this book.</td>
+//                                            </tr>
+//                                            <tr>
+//                                                <td>povCharacters</td>
+//                                                <td>array of strings</td>
+//                                                <td>An array of Character resource URLs that has had a POV-chapter in this book.</td>
+//                                            </tr>
+//                                        </tbody>
+//                                    </table>
+
+
+//                                    <h5>List all books:</h5>
+//                                    <select id="allBooks-lang">
+//                                        <option value="bash">cURL</option>
+//                                        <option value="python">Python</option>
+//                                        <option value="js">JavaScript</option>
+//                                    </select>
+//                                    <pre>
+//                                        <code class="language-bash line-numbers" id="allBooks-code">$ curl "https://www.anapioficeandfire.com/api/books"</code>
+//                                    </pre>
+//                                    <p>
+//                                        <strong>Example response:</strong>
+//                                    </p>
+//                                    <pre><code class="language-json line-numbers">[
+//                                        {
+//                                            "url": "https://www.anapioficeandfire.com/api/books/1",
+//                                        "name": "A Game of Thrones",
+//                                        "isbn": "978-0553103540",
+//                                        "authors": [
+//                                        "George R. R. Martin"
+//                                        ],
+//                                        "numberOfPages": 694,
+//                                        "publisher": "Bantam Books",
+//                                        "country": "United States",
+//                                        "mediaType": "Hardcover",
+//                                        "released": "1996-08-01T00:00:00",
+//                                        "characters": [
+//                                        "https://www.anapioficeandfire.com/api/characters/2",
+//                                        ...
+//                                        ],
+//                                        "povCharacters": [
+//                                        "https://www.anapioficeandfire.com/api/characters/148",
+//                                        ...
+//                                        ]
+//  },
+//                                        {
+//                                            "url": "https://www.anapioficeandfire.com/api/books/2",
+//                                        "name": "A Clash of Kings",
+//                                        "isbn": "978-0553108033",
+//                                        "authors": [
+//                                        "George R. R. Martin"
+//                                        ],
+//                                        "numberOfPages": 768,
+//                                        "publisher": "Bantam Books",
+//                                        "country": "United States",
+//                                        "mediaType": "Hardcover",
+//                                        "released": "1999-02-02T00:00:00",
+//                                        "characters": [
+//                                        "https://www.anapioficeandfire.com/api/characters/2",
+//                                        ...
+//                                        ],
+//                                        "povCharacters": [
+//                                        "https://www.anapioficeandfire.com/api/characters/148",
+//                                        ...
+//                                        ]
+//  },
+//                                        ...
+//                                        ]</code></pre>
+//                                    <p></p>
+//                                    <h5>Filtering books</h5>
+//                                    <p>You can also include filter parameters in your request to the books endpoint by including parameters in the query string.</p>
+//                                    <table>
+//                                        <thead>
+//                                            <tr>
+//                                                <th>Parameter</th>
+//                                                <th>Type</th>
+//                                                <th>Result</th>
+//                                            </tr>
+//                                        </thead>
+//                                        <tbody>
+//                                            <tr>
+//                                                <td>name</td>
+//                                                <td>string</td>
+//                                                <td>Books with the given name are included in the response</td>
+//                                            </tr>
+//                                            <tr>
+//                                                <td>fromReleaseDate</td>
+//                                                <td>date</td>
+//                                                <td>Books that were released after, or on, the given date are included in the response.</td>
+//                                            </tr>
+//                                            <tr>
+//                                                <td>toReleaseDate</td>
+//                                                <td>date</td>
+//                                                <td>Books that were released before, or on, the given date are included in the response.</td>
+//                                            </tr>
+//                                        </tbody>
+//                                    </table>
+
+//                                    <h5>Get specific book</h5>
+//                                    <select id="specificBook-lang">
+//                                        <option value="bash">cURL</option>
+//                                        <option value="python">Python</option>
+//                                        <option value="js">JavaScript</option>
+//                                    </select>
+//                                    <pre>
+//                                        <code class="language-bash line-numbers" id="specificBook-code">$ curl "https://www.anapioficeandfire.com/api/books/1"</code>
+//                                    </pre>
+//                                    <p>
+//                                        <strong>Example response:</strong>
+//                                    </p>
+//                                    <pre><code class="language-json line-numbers">{
+//                                        "url": "https://www.anapioficeandfire.com/api/books/1",
+//                                        "name": "A Game of Thrones",
+//                                        "isbn": "978-0553103540",
+//                                        "authors": [
+//                                        "George R. R. Martin"
+//                                        ],
+//                                        "numberOfPages": 694,
+//                                        "publisher": "Bantam Books",
+//                                        "country": "United States",
+//                                        "mediaType": "Hardcover",
+//                                        "released": "1996-08-01T00:00:00",
+//                                        "characters": [
+//                                        "https://www.anapioficeandfire.com/api/characters/2",
+//                                        ...
+//                                        ],
+//                                        "povCharacters": [
+//                                        "https://www.anapioficeandfire.com/api/characters/148",
+//                                        ...
+//                                        ]
+//}</code></pre>
+//                                </div>
+
+//                                <p></p>
+//                                <div>
+//                                    <a name="characters"></a>
+//                                    <h4>Characters</h4>
+//                                    <p>A Character is an individual within the Ice And Fire universe.</p>
+//                                    <table>
+//                                        <thead>
+//                                            <tr>
+//                                                <th>Name</th>
+//                                                <th>Type</th>
+//                                                <th>Description</th>
+//                                            </tr>
+//                                        </thead>
+//                                        <tbody>
+//                                            <tr>
+//                                                <td>url</td>
+//                                                <td>string</td>
+//                                                <td>The hypermedia URL of this resource</td>
+//                                            </tr>
+//                                            <tr>
+//                                                <td>name</td>
+//                                                <td>string</td>
+//                                                <td>The name of this character</td>
+//                                            </tr>
+//                                            <tr>
+//                                                <td>gender</td>
+//                                                <td>string</td>
+//                                                <td>The gender of this character.</td>
+//                                            </tr>
+//                                            <tr>
+//                                                <td>culture</td>
+//                                                <td>string</td>
+//                                                <td>The culture that this character belongs to.</td>
+//                                            </tr>
+//                                            <tr>
+//                                                <td>born</td>
+//                                                <td>string</td>
+//                                                <td>Textual representation of when and where this character was born.</td>
+//                                            </tr>
+//                                            <tr>
+//                                                <td>died</td>
+//                                                <td>string</td>
+//                                                <td>Textual representation of when and where this character died.</td>
+//                                            </tr>
+//                                            <tr>
+//                                                <td>titles</td>
+//                                                <td>array of strings</td>
+//                                                <td>The titles that this character holds.</td>
+//                                            </tr>
+//                                            <tr>
+//                                                <td>aliases</td>
+//                                                <td>array of strings</td>
+//                                                <td>The aliases that this character goes by.</td>
+//                                            </tr>
+//                                            <tr>
+//                                                <td>father</td>
+//                                                <td>string</td>
+//                                                <td>The character resource URL of this character's father.</td>
+//                                            </tr>
+//                                            <tr>
+//                                                <td>mother</td>
+//                                                <td>string</td>
+//                                                <td>The character resource URL of this character's mother.</td>
+//                                            </tr>
+//                                            <tr>
+//                                                <td>spouse</td>
+//                                                <td>string</td>
+//                                                <td>An array of Character resource URLs that has had a POV-chapter in this book.</td>
+//                                            </tr>
+//                                            <tr>
+//                                                <td>allegiances</td>
+//                                                <td>array of strings</td>
+//                                                <td>An array of House resource URLs that this character is loyal to.</td>
+//                                            </tr>
+//                                            <tr>
+//                                                <td>books</td>
+//                                                <td>array of strings</td>
+//                                                <td>An array of Book resource URLs that this character has been in.</td>
+//                                            </tr>
+//                                            <tr>
+//                                                <td>povBooks</td>
+//                                                <td>array of strings</td>
+//                                                <td>An array of Book resource URLs that this character has had a POV-chapter in.</td>
+//                                            </tr>
+//                                            <tr>
+//                                                <td>tvSeries</td>
+//                                                <td>array of strings</td>
+//                                                <td>An array of names of the seasons of Game of Thrones that this character has been in.</td>
+//                                            </tr>
+//                                            <tr>
+//                                                <td>playedBy</td>
+//                                                <td>array of strings</td>
+//                                                <td>An array of actor names that has played this character in the TV show Game Of Thrones.</td>
+//                                            </tr>
+//                                        </tbody>
+//                                    </table>
+//                                    <h5>List all characters:</h5>
+//                                    <select id="allCharacters-lang">
+//                                        <option value="bash">cURL</option>
+//                                        <option value="python">Python</option>
+//                                        <option value="js">JavaScript</option>
+//                                    </select>
+//                                    <pre>
+//                                        <code class="language-bash line-numbers" id="allCharacters-code">$ curl "https://www.anapioficeandfire.com/api/characters"</code>
+//                                    </pre>
+//                                    <p>
+//                                        <strong>Example response:</strong>
+//                                    </p>
+//                                    <pre><code class="language-json line-numbers">[
+//                                        {
+//                                            "url": "https://www.anapioficeandfire.com/api/characters/1",
+//                                        "name": "",
+//                                        "culture": "Braavosi",
+//                                        "born": "",
+//                                        "died": "",
+//                                        "titles": [],
+//                                        "aliases": [
+//                                        "The Daughter of the Dusk"
+//                                        ],
+//                                        "father": "",
+//                                        "mother": "",
+//                                        "spouse": "",
+//                                        "allegiances": [],
+//                                        "books": [
+//                                        "https://www.anapioficeandfire.com/api/books/5"
+//                                        ],
+//                                        "povBooks": [],
+//                                        "tvSeries": [],
+//                                        "playedBy": []
+//  },
+//                                        {
+//                                            "url": "https://www.anapioficeandfire.com/api/characters/2",
+//                                        "name": "",
+//                                        "culture": "",
+//                                        "born": "",
+//                                        "died": "",
+//                                        "titles": [],
+//                                        "aliases": [
+//                                        "Hodor"
+//                                        ],
+//                                        "father": "",
+//                                        "mother": "",
+//                                        "spouse": "",
+//                                        "allegiances": [
+//                                        "https://www.anapioficeandfire.com/api/houses/362"
+//                                        ],
+//                                        "books": [
+//                                        "https://www.anapioficeandfire.com/api/books/1",
+//                                        ...
+//                                        ],
+//                                        "povBooks": [],
+//                                        "tvSeries": [
+//                                        "Season 1",
+//                                        "Season 2",
+//                                        "Season 3",
+//                                        "Season 4"
+//                                        ],
+//                                        "playedBy": [
+//                                        "Kristian Nairn"
+//                                        ]
+//  },
+//                                        ...
+//                                        ]</code></pre>
+//                                    <p></p>
+//                                    <h5>Filtering characters</h5>
+//                                    <p>You can also include filter parameters in your request to the characters endpoint by including parameters in the query string.</p>
+//                                    <table>
+//                                        <thead>
+//                                            <tr>
+//                                                <th>Parameter</th>
+//                                                <th>Type</th>
+//                                                <th>Result</th>
+//                                            </tr>
+//                                        </thead>
+//                                        <tbody>
+//                                            <tr>
+//                                                <td>name</td>
+//                                                <td>string</td>
+//                                                <td>Characters with the given name are included in the response.</td>
+//                                            </tr>
+//                                            <tr>
+//                                                <td>gender</td>
+//                                                <td>string</td>
+//                                                <td>Characters with the given gender are included in the response.</td>
+//                                            </tr>
+//                                            <tr>
+//                                                <td>culture</td>
+//                                                <td>string</td>
+//                                                <td>Characters with the given culture are included in the response.</td>
+//                                            </tr>
+//                                            <tr>
+//                                                <td>born</td>
+//                                                <td>string</td>
+//                                                <td>Characters that were born this given year are included in the response.</td>
+//                                            </tr>
+//                                            <tr>
+//                                                <td>died</td>
+//                                                <td>string</td>
+//                                                <td>Characters that died this given year are included in the response.</td>
+//                                            </tr>
+//                                            <tr>
+//                                                <td>isAlive</td>
+//                                                <td>boolean</td>
+//                                                <td>Characters that are alive or dead (depending on the value) are included in the response.</td>
+//                                            </tr>
+//                                        </tbody>
+//                                    </table>
+
+
+//                                    <h5>Get specific character</h5>
+//                                    <select id="specificCharacter-lang">
+//                                        <option value="bash">cURL</option>
+//                                        <option value="python">Python</option>
+//                                        <option value="js">JavaScript</option>
+//                                    </select>
+//                                    <pre>
+//                                        <code class="language-bash line-numbers" id="specificCharacter-code">$ curl "https://www.anapioficeandfire.com/api/characters/823"</code>
+//                                    </pre>
+//                                    <p>
+//                                        <strong>Example response:</strong>
+//                                    </p>
+//                                    <pre><code class="language-json line-numbers">{
+//                                        "url": "https://www.anapioficeandfire.com/api/characters/823",
+//                                        "name": "Petyr Baelish",
+//                                        "culture": "Valemen",
+//                                        "born": "In 268 AC, at the Fingers",
+//                                        "died": "",
+//                                        "titles": [
+//                                        "Master of coin (formerly)",
+//                                        "Lord Paramount of the Trident",
+//                                        "Lord of Harrenhal",
+//                                        "Lord Protector of the Vale"
+//                                        ],
+//                                        "aliases": [
+//                                        "Littlefinger"
+//                                        ],
+//                                        "father": "",
+//                                        "mother": "",
+//                                        "spouse": "https://www.anapioficeandfire.com/api/characters/688",
+//                                        "allegiances": [
+//                                        "https://www.anapioficeandfire.com/api/houses/10",
+//                                        "https://www.anapioficeandfire.com/api/houses/11"
+//                                        ],
+//                                        "books": [
+//                                        "https://www.anapioficeandfire.com/api/books/1",
+//                                        ...
+//                                        ],
+//                                        "povBooks": [],
+//                                        "tvSeries": [
+//                                        "Season 1",
+//                                        "Season 2",
+//                                        "Season 3",
+//                                        "Season 4",
+//                                        "Season 5"
+//                                        ],
+//                                        "playedBy": [
+//                                        "Aidan Gillen"
+//                                        ]
+//}</code></pre>
+//                                    <p></p>
+//                                </div>
+//                                <div>
+//                                    <a name="houses"></a>
+//                                    <h4>Houses</h4>
+//                                    <p>A House is a house branch within the Ice And Fire universe.</p>
+//                                    <table>
+//                                        <thead>
+//                                            <tr>
+//                                                <th>Name</th>
+//                                                <th>Type</th>
+//                                                <th>Description</th>
+//                                            </tr>
+//                                        </thead>
+//                                        <tbody>
+//                                            <tr>
+//                                                <td>url</td>
+//                                                <td>string</td>
+//                                                <td>The hypermedia URL of this resource</td>
+//                                            </tr>
+//                                            <tr>
+//                                                <td>name</td>
+//                                                <td>string</td>
+//                                                <td>The name of this house</td>
+//                                            </tr>
+//                                            <tr>
+//                                                <td>region</td>
+//                                                <td>string</td>
+//                                                <td>The region that this house resides in.</td>
+//                                            </tr>
+//                                            <tr>
+//                                                <td>coatOfArms</td>
+//                                                <td>string</td>
+//                                                <td>Text describing the coat of arms of this house.</td>
+//                                            </tr>
+//                                            <tr>
+//                                                <td>words</td>
+//                                                <td>string</td>
+//                                                <td>The words of this house.</td>
+//                                            </tr>
+//                                            <tr>
+//                                                <td>titles</td>
+//                                                <td>array of strings</td>
+//                                                <td>The titles that this house holds.</td>
+//                                            </tr>
+//                                            <tr>
+//                                                <td>seats</td>
+//                                                <td>array of strings</td>
+//                                                <td>The seats that this house holds.</td>
+//                                            </tr>
+//                                            <tr>
+//                                                <td>currentLord</td>
+//                                                <td>string</td>
+//                                                <td>The Character resource URL of this house's current lord.</td>
+//                                            </tr>
+//                                            <tr>
+//                                                <td>heir</td>
+//                                                <td>string</td>
+//                                                <td>The Character resource URL of this house's heir.</td>
+//                                            </tr>
+//                                            <tr>
+//                                                <td>overlord</td>
+//                                                <td>string</td>
+//                                                <td>The House resource URL that this house answers to.</td>
+//                                            </tr>
+//                                            <tr>
+//                                                <td>founded</td>
+//                                                <td>string</td>
+//                                                <td>The year that this house was founded.</td>
+//                                            </tr>
+//                                            <tr>
+//                                                <td>founder</td>
+//                                                <td>string</td>
+//                                                <td>The Character resource URL that founded this house.</td>
+//                                            </tr>
+//                                            <tr>
+//                                                <td>diedOut</td>
+//                                                <td>string</td>
+//                                                <td>The year that this house died out.</td>
+//                                            </tr>
+//                                            <tr>
+//                                                <td>ancestralWeapons</td>
+//                                                <td>array of strings</td>
+//                                                <td>An array of names of the noteworthy weapons that this house owns.</td>
+//                                            </tr>
+//                                            <tr>
+//                                                <td>cadetBranches</td>
+//                                                <td>array of strings</td>
+//                                                <td>An array of House resource URLs that was founded from this house.</td>
+//                                            </tr>
+//                                            <tr>
+//                                                <td>swornMembers</td>
+//                                                <td>array of strings</td>
+//                                                <td>An array of Character resource URLs that are sworn to this house.</td>
+//                                            </tr>
+//                                        </tbody>
+//                                    </table>
+
+//                                    <h5>List all houses:</h5>
+//                                    <select id="allHouses-lang">
+//                                        <option value="bash">cURL</option>
+//                                        <option value="python">Python</option>
+//                                        <option value="js">JavaScript</option>
+//                                    </select>
+//                                    <pre>
+//                                        <code class="language-bash line-numbers" id="allHouses-code">$ curl "https://www.anapioficeandfire.com/api/houses"</code>
+//                                    </pre>
+//                                    <p>
+//                                        <strong>Example response:</strong>
+//                                    </p>
+//                                    <pre><code class="language-json line-numbers">[
+//                                        {
+//                                            "url": "https://www.anapioficeandfire.com/api/houses/1",
+//                                        "name": "House Algood",
+//                                        "region": "The Westerlands",
+//                                        "coatOfArms": "A golden wreath, on a blue field with a gold border",
+//                                        "words": "",
+//                                        "titles": [],
+//                                        "seats": [],
+//                                        "currentLord": "",
+//                                        "heir": "",
+//                                        "overlord": "https://www.anapioficeandfire.com/api/houses/229",
+//                                        "founded": "",
+//                                        "founder": "",
+//                                        "diedOut": "",
+//                                        "ancestralWeapons": [],
+//                                        "cadetBranches": [],
+//                                        "swornMembers": []
+//  },
+//                                        {
+//                                            "url": "https://www.anapioficeandfire.com/api/houses/2",
+//                                        "name": "House Allyrion of Godsgrace",
+//                                        "region": "Dorne",
+//                                        "coatOfArms": "Gyronny Gules and Sable, a hand couped Or",
+//                                        "words": "No Foe May Pass",
+//                                        "titles": [],
+//                                        "seats": [
+//                                        "Godsgrace"
+//                                        ],
+//                                        "currentLord": "https://www.anapioficeandfire.com/api/characters/298",
+//                                        "heir": "https://www.anapioficeandfire.com/api/characters/1922",
+//                                        "overlord": "https://www.anapioficeandfire.com/api/houses/285",
+//                                        "founded": "",
+//                                        "founder": "",
+//                                        "diedOut": "",
+//                                        "ancestralWeapons": [],
+//                                        "cadetBranches": [],
+//                                        "swornMembers": [
+//                                        "https://www.anapioficeandfire.com/api/characters/1301",
+//                                        ...
+//                                        ]
+//  },
+//                                        ...
+//                                        ]</code></pre>
+//                                    <p></p>
+
+//                                    <h5>Filtering houses</h5>
+//                                    <p>You can also include filter parameters in your request to the characters endpoint by including parameters in the query string.</p>
+//                                    <table>
+//                                        <thead>
+//                                            <tr>
+//                                                <th>Parameter</th>
+//                                                <th>Type</th>
+//                                                <th>Result</th>
+//                                            </tr>
+//                                        </thead>
+//                                        <tbody>
+//                                            <tr>
+//                                                <td>name</td>
+//                                                <td>string</td>
+//                                                <td>Houses with the given name are included in the response</td>
+//                                            </tr>
+//                                            <tr>
+//                                                <td>region</td>
+//                                                <td>string</td>
+//                                                <td>Houses that belong in the given region are included in the response.</td>
+//                                            </tr>
+//                                            <tr>
+//                                                <td>words</td>
+//                                                <td>string</td>
+//                                                <td>Houses that has the given words are included in the response.</td>
+//                                            </tr>
+//                                            <tr>
+//                                                <td>hasWords</td>
+//                                                <td>boolean</td>
+//                                                <td>Houses that have words (or not) are included in the response.</td>
+//                                            </tr>
+//                                            <tr>
+//                                                <td>hasTitles</td>
+//                                                <td>boolean</td>
+//                                                <td>Houses that have titles (or not) are included in the response.</td>
+//                                            </tr>
+//                                            <tr>
+//                                                <td>hasSeats</td>
+//                                                <td>boolean</td>
+//                                                <td>Houses that have seats (or not) are included in the response.</td>
+//                                            </tr>
+//                                            <tr>
+//                                                <td>hasDiedOut</td>
+//                                                <td>boolean</td>
+//                                                <td>Houses that are extinct are included in the response.</td>
+//                                            </tr>
+//                                            <tr>
+//                                                <td>hasAncestralWeapons</td>
+//                                                <td>boolean</td>
+//                                                <td>Houses that have ancestral weapons (or not) are included in the response.</td>
+//                                            </tr>
+//                                        </tbody>
+//                                    </table>
+
+
+//                                    <h5>Get specific house</h5>
+//                                    <select id="specificHouse-lang">
+//                                        <option value="bash">cURL</option>
+//                                        <option value="python">Python</option>
+//                                        <option value="js">JavaScript</option>
+//                                    </select>
+//                                    <pre>
+//                                        <code class="language-bash line-numbers" id="specificHouse-code">$ curl "https://www.anapioficeandfire.com/api/houses/10"</code>
+//                                    </pre>
+//                                    <p>
+//                                        <strong>Example response:</strong>
+//                                    </p>
+//                                    <pre><code class="language-json line-numbers">{
+//                                        "url": "https://www.anapioficeandfire.com/api/houses/10",
+//                                        "name": "House Baelish of Harrenhal",
+//                                        "region": "The Riverlands",
+//                                        "coatOfArms": "A field of silver mockingbirds, on a green field",
+//                                        "words": "",
+//                                        "titles": [
+//                                        "Lord Paramount of the Trident",
+//                                        "Lord of Harrenhal"
+//                                        ],
+//                                        "seats": [
+//                                        "Harrenhal"
+//                                        ],
+//                                        "currentLord": "https://www.anapioficeandfire.com/api/characters/823",
+//                                        "heir": "",
+//                                        "overlord": "https://www.anapioficeandfire.com/api/houses/16",
+//                                        "founded": "299 AC",
+//                                        "founder": "https://www.anapioficeandfire.com/api/characters/823",
+//                                        "diedOut": "",
+//                                        "ancestralWeapons": [],
+//                                        "cadetBranches": [],
+//                                        "swornMembers": [
+//                                        "https://www.anapioficeandfire.com/api/characters/651",
+//                                        "https://www.anapioficeandfire.com/api/characters/804",
+//                                        "https://www.anapioficeandfire.com/api/characters/823",
+//                                        "https://www.anapioficeandfire.com/api/characters/957",
+//                                        "https://www.anapioficeandfire.com/api/characters/970"
+//                                        ]
+//}</code></pre>
+//                                    <p></p>
+//                                </div>
+//                            </div>
+
+//                            @Html.Partial("_Libraries")
+//                        </div>
+//                        <div class="small-12 medium-4 column hide-for-small-only">
+//                            @Html.Partial("_Menu")
+//                        </div>
+//                    </div>
+//                </article>
+//            </div>
+//        </section>
+//    </div >
+//</div >`

--- a/tests/AnApiOfIceAndFire.Tests/Views/test.js
+++ b/tests/AnApiOfIceAndFire.Tests/Views/test.js
@@ -1,6 +1,9 @@
 ﻿﻿/// <reference path="../../../src/AnApiOfIceAndFire/wwwroot/script.js" />
 
 // TODO: figure out how to use JSDOM in this file to test the setCodeSnippetsText and addOnChangeListener functions
+// it seems like there should be a way to do this within the engine that the test runner uses to execute the JS code but I'm not seeing how in the documentation...
+//const jsdom = require("jsdom");
+//const { JSDOM } = jsdom;
 
 
 describe("test maybeAddForwardSlash function", function () {
@@ -35,888 +38,897 @@ describe("test code snippet functions", function () {
 })
 
 
-//describe("", function () {
+// these tests will not pass if run with Chutzpah, however, they do pass if run with a test runner that allows the use of JSDOM
+describe("test event listener functions", function () {
 
-//    beforeEach(function () {
-//        document.body.innerHTML = documentationPageHTMLStr;
-//    });
+    beforeAll(function () {
+        const dom = new JSDOM();
+        const document = dom.window.document;
+    });
+    
+    beforeEach(function () {
+        document.body.innerHTML = `<body>${documentationPageHtmlStr}</body>`;
+        addOnChangeListener();
+    });
 
-//    it("should set element's innerHTML to code snippets", function () {
-//        setCodeSnippetsText(mockEvent);
-//        const elem = document.getElementById("books-code");
-//        expect(elem.innerHTML).toEqual(pythonCodeSnippetBooksResource);
-//    });
+    it("should set the allBooks code snippet's innerHTML to match the python code snippet", function () {
+        setCodeSnippetsText(mockEvent);
+        const elem = document.getElementById("allBooks-code");
+        expect(elem.innerHTML).toEqual(pythonCodeSnippetBooksResource);
+    });
 
-//    it("should set element's class name to language-python", function () {
-//        setCodeSnippetsText(mockEvent);
-//        const elem = document.getElementById("books-code");
-//        expect(elem.className).toEqual("language-python");
-//    });
+    it("should set the allBooks code element's class name to language-python", function () {
+        setCodeSnippetsText(mockEvent);
+        const elem = document.getElementById("allBooks-code");
+        expect(elem.className).toEqual("language-python");
+    });
 
-//    it("should dropdown language selection's value to python", function () {
-//        setCodeSnippetsText(mockEvent);
-//        const elem = document.getElementById("books-lang");
-//        expect(elem.value).toEqual(mockEvent.target.value);
-//    });
-//})
+    it("should set the allBooks language dropdown menu's value to python", function () {
+        setCodeSnippetsText(mockEvent);
+        const elem = document.getElementById("allBooks-lang");
+        expect(elem.value).toEqual(mockEvent.target.value);
+    });
+})
 
 
 const pythonCodeSnippetBooksResource = `import logging\nimport requests\n\nAN_API_OF_ICE_AND_FIRE_BASE_URL = "https://www.anapioficeandfire.com/api"\n\ndef get_books():\n    url = f"{AN_API_OF_ICE_AND_FIRE_BASE_URL}/books"\n    resp = requests.get(url)\n    if resp.status_code != 200:\n        logging.info(f"Error on request to {url}: {resp.text}")\n        return None\n    return resp.json()\n\nbooks = get_books()\nprint(books)`;
 
-//const mockEvent = { target: { value: "python" } };
 
-//const documentationPageHTMLStr = `<div id="layout-main - container" class="row">
-//    < div id = "layout-content" class="large-12 columns" >
-//        <section id="content" class="row">
-//            <div class="large-12 columns">
-//                <article>
-//                    <header id="page-header">
-//                        <h1 class="page-title">Documentation</h1>
-//                    </header>
-//                    <div class="row">
-//                        <div class="small-12 column show-for-small-only">
-//                            @Html.Partial("_Menu")
-//                        </div>
-//                        <div class="small-12 medium-8 column">
-//                            <hr />
-//                            <div>
-//                                <a name="intro"></a>
-//                                <h4>Introduction</h4>
-//                                <p>This documentation will help you familiarise yourself with the API and how to consume the different resources that are available. The documentation provides all information needed to get started and it also has educational examples for all resources.</p>
-//                                <p>
-//                                    If you're interested in using a native implementation, please take a look at the <strong>Libraries</strong> section.
-//                                </p>
-//                            </div>
-//                            <div>
-//                                <a name="current-version"></a>
-//                                <h4>Current Version</h4>
-//                                <p>The current version of the API is 1.</p>
-//                            </div>
-//                            <div>
-//                                <a name="authentication"></a>
-//                                <h4>Authentication</h4>
-//                                <p>An API of Ice And Fire is an open API. This means that no authentication is required to query the API for data. Since no authentication is required, there is only support for GET-ing data.</p>
-//                            </div>
-//                            <div>
-//                                <a name="pagination"></a>
-//                                <h4>Pagination</h4>
-//                                <p>An API of Ice And Fire provides a lot of data about the world of Westeros. To prevent our servers from getting cranky, the API will automatically paginate the responses. You will learn how to create requests with pagination parameters and consume the response.</p>
+const mockEvent = { target: { value: "python" } };
 
-//                                <h5>Things worth noting:</h5>
+// TODO: research how to import the content of the Index.cshtml file into this file so we don't have to copy and paste here anytime anything in that file changes
+const documentationPageHtmlStr = `<div id="layout-main-container" class="row">
+    <div id="layout-content" class="large-12 columns">
+        <section id="content" class="row">
+            <div class="large-12 columns">
+                <article>
+                    <header id="page-header">
+                        <h1 class="page-title">Documentation</h1>
+                    </header>
+                    <div class="row">
+                        <div class="small-12 column show-for-small-only">
+                            @Html.Partial("_Menu")
+                        </div>
+                        <div class="small-12 medium-8 column">
+                            <hr />
+                            <div>
+                                <a name="intro"></a>
+                                <h4>Introduction</h4>
+                                <p>This documentation will help you familiarise yourself with the API and how to consume the different resources that are available. The documentation provides all information needed to get started and it also has educational examples for all resources.</p>
+                                <p>
+                                    If you're interested in using a native implementation, please take a look at the <strong>Libraries</strong> section.
+                                </p>
+                            </div>
+                            <div>
+                                <a name="current-version"></a>
+                                <h4>Current Version</h4>
+                                <p>The current version of the API is 1.</p>
+                            </div>
+                            <div>
+                                <a name="authentication"></a>
+                                <h4>Authentication</h4>
+                                <p>An API of Ice And Fire is an open API. This means that no authentication is required to query the API for data. Since no authentication is required, there is only support for GET-ing data.</p>
+                            </div>
+                            <div>
+                                <a name="pagination"></a>
+                                <h4>Pagination</h4>
+                                <p>An API of Ice And Fire provides a lot of data about the world of Westeros. To prevent our servers from getting cranky, the API will automatically paginate the responses. You will learn how to create requests with pagination parameters and consume the response.</p>
 
-//                                <ol>
-//                                    <li>Information about the pagination is included in <a href="https://tools.ietf.org/html/rfc5988">the Link header</a></li>
-//                                    <li>Page numbering is 1-based</li>
-//                                    <li>You can specify how many items you want to receive per page, the maximum is 50</li>
-//                                </ol>
+                                <h5>Things worth noting:</h5>
 
-//                                <h5>Constructing a request with pagination</h5>
-//                                <p>
-//                                    You specify which page you want to access with the <code>?page</code> parameter, if you don't provide the <code>?page</code> parameter the first page will be returned. You can also specify the size of the page with the <code>?pageSize</code> parameter, if you don't provide the <code>?pageSize</code> parameter the default size of 10 will be used.
-//                                </p>
-//                                <p>Let's make a request for the first page of characters with a page size of 10. Since we're only interested in the pagination information we provide the -I parameter to say that we only care about the headers.</p>
+                                <ol>
+                                    <li>Information about the pagination is included in <a href="https://tools.ietf.org/html/rfc5988">the Link header</a></li>
+                                    <li>Page numbering is 1-based</li>
+                                    <li>You can specify how many items you want to receive per page, the maximum is 50</li>
+                                </ol>
 
-//                                <code>$ curl -I "https://www.anapioficeandfire.com/api/characters?page=1&pageSize=10"</code>
-//                                <p>
-//                                    <strong>Here's the link header in the response:</strong>
-//                                </p>
-//                                <code>
+                                <h5>Constructing a request with pagination</h5>
+                                <p>
+                                    You specify which page you want to access with the <code>?page</code> parameter, if you don't provide the <code>?page</code> parameter the first page will be returned. You can also specify the size of the page with the <code>?pageSize</code> parameter, if you don't provide the <code>?pageSize</code> parameter the default size of 10 will be used.
+                                </p>
+                                <p>Let's make a request for the first page of characters with a page size of 10. Since we're only interested in the pagination information we provide the -I parameter to say that we only care about the headers.</p>
+                                
+                                <code>$ curl -I "https://www.anapioficeandfire.com/api/characters?page=1&pageSize=10"</code>
+                                <p>
+                                    <strong>Here's the link header in the response:</strong>
+                                </p>
+                                <code>
 
-//                                    Link: &lt;https://www.anapioficeandfire.com/api/characters?page=2&amp;pageSize=10&gt;; rel="next",
-//                                    &lt;https://www.anapioficeandfire.com/api/characters?page=1&amp;pageSize=10&gt;; rel="first",
-//                                    &lt;https://www.anapioficeandfire.com/api/characters?page=214&amp;pageSize=10&gt;; rel="last"
-//                                </code>
-//                                <p></p>
-//                                <h5>Possible link types:</h5>
-//                                <ul>
-//                                    <li>
-//                                        <strong>next</strong> - Next page of results
-//                                    </li>
-//                                    <li>
-//                                        <strong>prev</strong> - Previous page of results
-//                                    </li>
-//                                    <li>
-//                                        <strong>first</strong> - First page of results
-//                                    </li>
-//                                    <li>
-//                                        <strong>last</strong> - Last page of results
-//                                    </li>
-//                                </ul>
+                                    Link: &lt;https://www.anapioficeandfire.com/api/characters?page=2&amp;pageSize=10&gt;; rel="next",
+                                    &lt;https://www.anapioficeandfire.com/api/characters?page=1&amp;pageSize=10&gt;; rel="first",
+                                    &lt;https://www.anapioficeandfire.com/api/characters?page=214&amp;pageSize=10&gt;; rel="last"
+                                </code>
+                                <p></p>
+                                <h5>Possible link types:</h5>
+                                <ul>
+                                    <li>
+                                        <strong>next</strong> - Next page of results
+                                    </li>
+                                    <li>
+                                        <strong>prev</strong> - Previous page of results
+                                    </li>
+                                    <li>
+                                        <strong>first</strong> - First page of results
+                                    </li>
+                                    <li>
+                                        <strong>last</strong> - Last page of results
+                                    </li>
+                                </ul>
 
-//                                <p>These links can then be used to navigate to other pages of results.</p>
-//                            </div>
-//                            <div>
-//                                <a name="rate-limiting"></a>
-//                                <h4>Rate Limiting</h4>
-//                                <p>To prevent malicious usage of our API we've a limit on the number of requests a given IP address can make to the API. This limit is set to 20000 requests per day. There should be no reason for hitting the limit if you implement proper caching strategies in your client. If you happen to hit the limit you'll receive a 403 Forbidden on all your requests for the remainder of the 24 hour time period.</p>
-//                            </div>
-//                            <div>
-//                                <a name="caching"></a>
-//                                <h4>Caching</h4>
-//                                <p>Apart from the standard cache headers such as max-age we also provide a few different ways to ease the load on our servers and your client. Each API response includes the ETag-header and the Last-Modified header. These headers can be used to ask our server if the data has changed or not. If the data has not changed you will receive an empty response body with a 304 Not Modified. If the data has changed you will receive a 200 with the updated data.</p>
+                                <p>These links can then be used to navigate to other pages of results.</p>
+                            </div>
+                            <div>
+                                <a name="rate-limiting"></a>
+                                <h4>Rate Limiting</h4>
+                                <p>To prevent malicious usage of our API we've a limit on the number of requests a given IP address can make to the API. This limit is set to 20000 requests per day. There should be no reason for hitting the limit if you implement proper caching strategies in your client. If you happen to hit the limit you'll receive a 403 Forbidden on all your requests for the remainder of the 24 hour time period.</p>
+                            </div>
+                            <div>
+                                <a name="caching"></a>
+                                <h4>Caching</h4>
+                                <p>Apart from the standard cache headers such as max-age we also provide a few different ways to ease the load on our servers and your client. Each API response includes the ETag-header and the Last-Modified header. These headers can be used to ask our server if the data has changed or not. If the data has not changed you will receive an empty response body with a 304 Not Modified. If the data has changed you will receive a 200 with the updated data.</p>
 
-//                                <h5>To use the ETag, include the following header in your request:</h5>
-//                                <code>If-None-Match: "your_etag_here"</code>
-//                                <p></p>
-//                                <h5>To use Last-Modified, include the following header in your request:</h5>
-//                                <code>If-Modified-Since: "date_here"</code>
-//                                <p></p>
-//                            </div>
-//                            <div>
-//                                <a name="versioning"></a>
-//                                <h4>Versioning</h4>
-//                                <p>Custom media types are used in An API of Ice And Fire to let consumers choose which version of the data they wish to receive. This is done by adding the following type to the Accept header when you make a request. Note that media types are specific to resources, this allows them to change independently from each other.</p>
+                                <h5>To use the ETag, include the following header in your request:</h5>
+                                <code>If-None-Match: "your_etag_here"</code>
+                                <p></p>
+                                <h5>To use Last-Modified, include the following header in your request:</h5>
+                                <code>If-Modified-Since: "date_here"</code>
+                                <p></p>
+                            </div>
+                            <div>
+                                <a name="versioning"></a>
+                                <h4>Versioning</h4>
+                                <p>Custom media types are used in An API of Ice And Fire to let consumers choose which version of the data they wish to receive. This is done by adding the following type to the Accept header when you make a request. Note that media types are specific to resources, this allows them to change independently from each other.</p>
 
-//                                <p>
-//                                    <strong>Important:</strong> If a version is not specified in the request the default version will be used. The default version may change in the future and can thus break the consumer's application. Make sure to always request a specific version in the <code>Accept</code> header as shown in the example below.
-//                                </p>
+                                <p>
+                                    <strong>Important:</strong> If a version is not specified in the request the default version will be used. The default version may change in the future and can thus break the consumer's application. Make sure to always request a specific version in the <code>Accept</code> header as shown in the example below.
+                                </p>
 
-//                                <h5>You specify a version like so:</h5>
-//                                <code>application/vnd.anapioficeandfire+json; version=1</code>
-//                                <p></p>
-//                            </div>
-
-
-
-//                            <h3>Resources</h3>
-//                            <hr />
-//                            <div>
-//                                <a name="root"></a>
-//                                <h4>Root</h4>
-//                                <p>The Root resource contains information about all available resources in the API.</p>
-//                                <h5>Example request:</h5>
-//                                <select id="root-lang">
-//                                    <option value="bash">cURL</option>
-//                                    <option value="python">Python</option>
-//                                    <option value="js">JavaScript</option>
-//                                </select>
-//                                <pre>
-//                                    <code class="language-bash line-numbers" id="root-code">$ curl "https://www.anapioficeandfire.com/api"</code>
-//                                </pre>
-//                                <h5>Example response:</h5>
-//                                <pre><code class="language-json line-numbers">{
-//                                    "books": "https://www.anapioficeandfire.com/api/books",
-//                                    "characters": "https://www.anapioficeandfire.com/api/characters",
-//                                    "houses": "https://www.anapioficeandfire.com/api/houses"
-// }
-//                                </code></pre>
-//                                <p></p>
-//                                <div>
-//                                    <a name="books"></a>
-//                                    <h4>Books</h4>
-//                                    <table>
-//                                        <thead>
-//                                            <tr>
-//                                                <th>Name</th>
-//                                                <th>Type</th>
-//                                                <th>Description</th>
-//                                            </tr>
-//                                        </thead>
-//                                        <tbody>
-//                                            <tr>
-//                                                <td>url</td>
-//                                                <td>string</td>
-//                                                <td>The hypermedia URL of this resource</td>
-//                                            </tr>
-//                                            <tr>
-//                                                <td>name</td>
-//                                                <td>string</td>
-//                                                <td>The name of this book</td>
-//                                            </tr>
-//                                            <tr>
-//                                                <td>isbn</td>
-//                                                <td>string</td>
-//                                                <td>The International Standard Book Number (ISBN-13) that uniquely identifies this book.</td>
-//                                            </tr>
-//                                            <tr>
-//                                                <td>authors</td>
-//                                                <td>array of strings</td>
-//                                                <td>An array of names of the authors that wrote this book.</td>
-//                                            </tr>
-//                                            <tr>
-//                                                <td>numberOfPages</td>
-//                                                <td>integer</td>
-//                                                <td>The number of pages in this book.</td>
-//                                            </tr>
-//                                            <tr>
-//                                                <td>publiser</td>
-//                                                <td>string</td>
-//                                                <td>The company that published this book.</td>
-//                                            </tr>
-//                                            <tr>
-//                                                <td>country</td>
-//                                                <td>string</td>
-//                                                <td>The country that this book was published in</td>
-//                                            </tr>
-//                                            <tr>
-//                                                <td>mediaType</td>
-//                                                <td>string</td>
-//                                                <td>The type of media this book was released in.</td>
-//                                            </tr>
-//                                            <tr>
-//                                                <td>released</td>
-//                                                <td>date</td>
-//                                                <td>The date (ISO 8601) when this book was released.</td>
-//                                            </tr>
-//                                            <tr>
-//                                                <td>characters</td>
-//                                                <td>array of strings</td>
-//                                                <td>An array of Character resource URLs that has been in this book.</td>
-//                                            </tr>
-//                                            <tr>
-//                                                <td>povCharacters</td>
-//                                                <td>array of strings</td>
-//                                                <td>An array of Character resource URLs that has had a POV-chapter in this book.</td>
-//                                            </tr>
-//                                        </tbody>
-//                                    </table>
+                                <h5>You specify a version like so:</h5>
+                                <code>application/vnd.anapioficeandfire+json; version=1</code>
+                                <p></p>
+                            </div>
 
 
-//                                    <h5>List all books:</h5>
-//                                    <select id="allBooks-lang">
-//                                        <option value="bash">cURL</option>
-//                                        <option value="python">Python</option>
-//                                        <option value="js">JavaScript</option>
-//                                    </select>
-//                                    <pre>
-//                                        <code class="language-bash line-numbers" id="allBooks-code">$ curl "https://www.anapioficeandfire.com/api/books"</code>
-//                                    </pre>
-//                                    <p>
-//                                        <strong>Example response:</strong>
-//                                    </p>
-//                                    <pre><code class="language-json line-numbers">[
-//                                        {
-//                                            "url": "https://www.anapioficeandfire.com/api/books/1",
-//                                        "name": "A Game of Thrones",
-//                                        "isbn": "978-0553103540",
-//                                        "authors": [
-//                                        "George R. R. Martin"
-//                                        ],
-//                                        "numberOfPages": 694,
-//                                        "publisher": "Bantam Books",
-//                                        "country": "United States",
-//                                        "mediaType": "Hardcover",
-//                                        "released": "1996-08-01T00:00:00",
-//                                        "characters": [
-//                                        "https://www.anapioficeandfire.com/api/characters/2",
-//                                        ...
-//                                        ],
-//                                        "povCharacters": [
-//                                        "https://www.anapioficeandfire.com/api/characters/148",
-//                                        ...
-//                                        ]
-//  },
-//                                        {
-//                                            "url": "https://www.anapioficeandfire.com/api/books/2",
-//                                        "name": "A Clash of Kings",
-//                                        "isbn": "978-0553108033",
-//                                        "authors": [
-//                                        "George R. R. Martin"
-//                                        ],
-//                                        "numberOfPages": 768,
-//                                        "publisher": "Bantam Books",
-//                                        "country": "United States",
-//                                        "mediaType": "Hardcover",
-//                                        "released": "1999-02-02T00:00:00",
-//                                        "characters": [
-//                                        "https://www.anapioficeandfire.com/api/characters/2",
-//                                        ...
-//                                        ],
-//                                        "povCharacters": [
-//                                        "https://www.anapioficeandfire.com/api/characters/148",
-//                                        ...
-//                                        ]
-//  },
-//                                        ...
-//                                        ]</code></pre>
-//                                    <p></p>
-//                                    <h5>Filtering books</h5>
-//                                    <p>You can also include filter parameters in your request to the books endpoint by including parameters in the query string.</p>
-//                                    <table>
-//                                        <thead>
-//                                            <tr>
-//                                                <th>Parameter</th>
-//                                                <th>Type</th>
-//                                                <th>Result</th>
-//                                            </tr>
-//                                        </thead>
-//                                        <tbody>
-//                                            <tr>
-//                                                <td>name</td>
-//                                                <td>string</td>
-//                                                <td>Books with the given name are included in the response</td>
-//                                            </tr>
-//                                            <tr>
-//                                                <td>fromReleaseDate</td>
-//                                                <td>date</td>
-//                                                <td>Books that were released after, or on, the given date are included in the response.</td>
-//                                            </tr>
-//                                            <tr>
-//                                                <td>toReleaseDate</td>
-//                                                <td>date</td>
-//                                                <td>Books that were released before, or on, the given date are included in the response.</td>
-//                                            </tr>
-//                                        </tbody>
-//                                    </table>
 
-//                                    <h5>Get specific book</h5>
-//                                    <select id="specificBook-lang">
-//                                        <option value="bash">cURL</option>
-//                                        <option value="python">Python</option>
-//                                        <option value="js">JavaScript</option>
-//                                    </select>
-//                                    <pre>
-//                                        <code class="language-bash line-numbers" id="specificBook-code">$ curl "https://www.anapioficeandfire.com/api/books/1"</code>
-//                                    </pre>
-//                                    <p>
-//                                        <strong>Example response:</strong>
-//                                    </p>
-//                                    <pre><code class="language-json line-numbers">{
-//                                        "url": "https://www.anapioficeandfire.com/api/books/1",
-//                                        "name": "A Game of Thrones",
-//                                        "isbn": "978-0553103540",
-//                                        "authors": [
-//                                        "George R. R. Martin"
-//                                        ],
-//                                        "numberOfPages": 694,
-//                                        "publisher": "Bantam Books",
-//                                        "country": "United States",
-//                                        "mediaType": "Hardcover",
-//                                        "released": "1996-08-01T00:00:00",
-//                                        "characters": [
-//                                        "https://www.anapioficeandfire.com/api/characters/2",
-//                                        ...
-//                                        ],
-//                                        "povCharacters": [
-//                                        "https://www.anapioficeandfire.com/api/characters/148",
-//                                        ...
-//                                        ]
-//}</code></pre>
-//                                </div>
-
-//                                <p></p>
-//                                <div>
-//                                    <a name="characters"></a>
-//                                    <h4>Characters</h4>
-//                                    <p>A Character is an individual within the Ice And Fire universe.</p>
-//                                    <table>
-//                                        <thead>
-//                                            <tr>
-//                                                <th>Name</th>
-//                                                <th>Type</th>
-//                                                <th>Description</th>
-//                                            </tr>
-//                                        </thead>
-//                                        <tbody>
-//                                            <tr>
-//                                                <td>url</td>
-//                                                <td>string</td>
-//                                                <td>The hypermedia URL of this resource</td>
-//                                            </tr>
-//                                            <tr>
-//                                                <td>name</td>
-//                                                <td>string</td>
-//                                                <td>The name of this character</td>
-//                                            </tr>
-//                                            <tr>
-//                                                <td>gender</td>
-//                                                <td>string</td>
-//                                                <td>The gender of this character.</td>
-//                                            </tr>
-//                                            <tr>
-//                                                <td>culture</td>
-//                                                <td>string</td>
-//                                                <td>The culture that this character belongs to.</td>
-//                                            </tr>
-//                                            <tr>
-//                                                <td>born</td>
-//                                                <td>string</td>
-//                                                <td>Textual representation of when and where this character was born.</td>
-//                                            </tr>
-//                                            <tr>
-//                                                <td>died</td>
-//                                                <td>string</td>
-//                                                <td>Textual representation of when and where this character died.</td>
-//                                            </tr>
-//                                            <tr>
-//                                                <td>titles</td>
-//                                                <td>array of strings</td>
-//                                                <td>The titles that this character holds.</td>
-//                                            </tr>
-//                                            <tr>
-//                                                <td>aliases</td>
-//                                                <td>array of strings</td>
-//                                                <td>The aliases that this character goes by.</td>
-//                                            </tr>
-//                                            <tr>
-//                                                <td>father</td>
-//                                                <td>string</td>
-//                                                <td>The character resource URL of this character's father.</td>
-//                                            </tr>
-//                                            <tr>
-//                                                <td>mother</td>
-//                                                <td>string</td>
-//                                                <td>The character resource URL of this character's mother.</td>
-//                                            </tr>
-//                                            <tr>
-//                                                <td>spouse</td>
-//                                                <td>string</td>
-//                                                <td>An array of Character resource URLs that has had a POV-chapter in this book.</td>
-//                                            </tr>
-//                                            <tr>
-//                                                <td>allegiances</td>
-//                                                <td>array of strings</td>
-//                                                <td>An array of House resource URLs that this character is loyal to.</td>
-//                                            </tr>
-//                                            <tr>
-//                                                <td>books</td>
-//                                                <td>array of strings</td>
-//                                                <td>An array of Book resource URLs that this character has been in.</td>
-//                                            </tr>
-//                                            <tr>
-//                                                <td>povBooks</td>
-//                                                <td>array of strings</td>
-//                                                <td>An array of Book resource URLs that this character has had a POV-chapter in.</td>
-//                                            </tr>
-//                                            <tr>
-//                                                <td>tvSeries</td>
-//                                                <td>array of strings</td>
-//                                                <td>An array of names of the seasons of Game of Thrones that this character has been in.</td>
-//                                            </tr>
-//                                            <tr>
-//                                                <td>playedBy</td>
-//                                                <td>array of strings</td>
-//                                                <td>An array of actor names that has played this character in the TV show Game Of Thrones.</td>
-//                                            </tr>
-//                                        </tbody>
-//                                    </table>
-//                                    <h5>List all characters:</h5>
-//                                    <select id="allCharacters-lang">
-//                                        <option value="bash">cURL</option>
-//                                        <option value="python">Python</option>
-//                                        <option value="js">JavaScript</option>
-//                                    </select>
-//                                    <pre>
-//                                        <code class="language-bash line-numbers" id="allCharacters-code">$ curl "https://www.anapioficeandfire.com/api/characters"</code>
-//                                    </pre>
-//                                    <p>
-//                                        <strong>Example response:</strong>
-//                                    </p>
-//                                    <pre><code class="language-json line-numbers">[
-//                                        {
-//                                            "url": "https://www.anapioficeandfire.com/api/characters/1",
-//                                        "name": "",
-//                                        "culture": "Braavosi",
-//                                        "born": "",
-//                                        "died": "",
-//                                        "titles": [],
-//                                        "aliases": [
-//                                        "The Daughter of the Dusk"
-//                                        ],
-//                                        "father": "",
-//                                        "mother": "",
-//                                        "spouse": "",
-//                                        "allegiances": [],
-//                                        "books": [
-//                                        "https://www.anapioficeandfire.com/api/books/5"
-//                                        ],
-//                                        "povBooks": [],
-//                                        "tvSeries": [],
-//                                        "playedBy": []
-//  },
-//                                        {
-//                                            "url": "https://www.anapioficeandfire.com/api/characters/2",
-//                                        "name": "",
-//                                        "culture": "",
-//                                        "born": "",
-//                                        "died": "",
-//                                        "titles": [],
-//                                        "aliases": [
-//                                        "Hodor"
-//                                        ],
-//                                        "father": "",
-//                                        "mother": "",
-//                                        "spouse": "",
-//                                        "allegiances": [
-//                                        "https://www.anapioficeandfire.com/api/houses/362"
-//                                        ],
-//                                        "books": [
-//                                        "https://www.anapioficeandfire.com/api/books/1",
-//                                        ...
-//                                        ],
-//                                        "povBooks": [],
-//                                        "tvSeries": [
-//                                        "Season 1",
-//                                        "Season 2",
-//                                        "Season 3",
-//                                        "Season 4"
-//                                        ],
-//                                        "playedBy": [
-//                                        "Kristian Nairn"
-//                                        ]
-//  },
-//                                        ...
-//                                        ]</code></pre>
-//                                    <p></p>
-//                                    <h5>Filtering characters</h5>
-//                                    <p>You can also include filter parameters in your request to the characters endpoint by including parameters in the query string.</p>
-//                                    <table>
-//                                        <thead>
-//                                            <tr>
-//                                                <th>Parameter</th>
-//                                                <th>Type</th>
-//                                                <th>Result</th>
-//                                            </tr>
-//                                        </thead>
-//                                        <tbody>
-//                                            <tr>
-//                                                <td>name</td>
-//                                                <td>string</td>
-//                                                <td>Characters with the given name are included in the response.</td>
-//                                            </tr>
-//                                            <tr>
-//                                                <td>gender</td>
-//                                                <td>string</td>
-//                                                <td>Characters with the given gender are included in the response.</td>
-//                                            </tr>
-//                                            <tr>
-//                                                <td>culture</td>
-//                                                <td>string</td>
-//                                                <td>Characters with the given culture are included in the response.</td>
-//                                            </tr>
-//                                            <tr>
-//                                                <td>born</td>
-//                                                <td>string</td>
-//                                                <td>Characters that were born this given year are included in the response.</td>
-//                                            </tr>
-//                                            <tr>
-//                                                <td>died</td>
-//                                                <td>string</td>
-//                                                <td>Characters that died this given year are included in the response.</td>
-//                                            </tr>
-//                                            <tr>
-//                                                <td>isAlive</td>
-//                                                <td>boolean</td>
-//                                                <td>Characters that are alive or dead (depending on the value) are included in the response.</td>
-//                                            </tr>
-//                                        </tbody>
-//                                    </table>
+                            <h3>Resources</h3>
+                            <hr />
+                            <div>
+                                <a name="root"></a>
+                                <h4>Root</h4>
+                                <p>The Root resource contains information about all available resources in the API.</p>
+                                <h5>Example request:</h5>
+                                <select id="root-lang">
+                                    <option value="bash">cURL</option>
+                                    <option value="python">Python</option>
+                                    <option value="js">JavaScript</option>
+                                </select>
+                                <pre>
+                                    <code class="language-bash line-numbers" id="root-code">$ curl "https://www.anapioficeandfire.com/api"</code>
+                                </pre>
+                                <h5>Example response:</h5>
+                                <pre><code class="language-json line-numbers">{
+    "books": "https://www.anapioficeandfire.com/api/books",
+    "characters": "https://www.anapioficeandfire.com/api/characters",
+    "houses": "https://www.anapioficeandfire.com/api/houses"
+ }
+</code></pre>
+                                <p></p>
+                                <div>
+                                    <a name="books"></a>
+                                    <h4>Books</h4>
+                                    <table>
+                                        <thead>
+                                            <tr>
+                                                <th>Name</th>
+                                                <th>Type</th>
+                                                <th>Description</th>
+                                            </tr>
+                                        </thead>
+                                        <tbody>
+                                            <tr>
+                                                <td>url</td>
+                                                <td>string</td>
+                                                <td>The hypermedia URL of this resource</td>
+                                            </tr>
+                                            <tr>
+                                                <td>name</td>
+                                                <td>string</td>
+                                                <td>The name of this book</td>
+                                            </tr>
+                                            <tr>
+                                                <td>isbn</td>
+                                                <td>string</td>
+                                                <td>The International Standard Book Number (ISBN-13) that uniquely identifies this book.</td>
+                                            </tr>
+                                            <tr>
+                                                <td>authors</td>
+                                                <td>array of strings</td>
+                                                <td>An array of names of the authors that wrote this book.</td>
+                                            </tr>
+                                            <tr>
+                                                <td>numberOfPages</td>
+                                                <td>integer</td>
+                                                <td>The number of pages in this book.</td>
+                                            </tr>
+                                            <tr>
+                                                <td>publiser</td>
+                                                <td>string</td>
+                                                <td>The company that published this book.</td>
+                                            </tr>
+                                            <tr>
+                                                <td>country</td>
+                                                <td>string</td>
+                                                <td>The country that this book was published in</td>
+                                            </tr>
+                                            <tr>
+                                                <td>mediaType</td>
+                                                <td>string</td>
+                                                <td>The type of media this book was released in.</td>
+                                            </tr>
+                                            <tr>
+                                                <td>released</td>
+                                                <td>date</td>
+                                                <td>The date (ISO 8601) when this book was released.</td>
+                                            </tr>
+                                            <tr>
+                                                <td>characters</td>
+                                                <td>array of strings</td>
+                                                <td>An array of Character resource URLs that has been in this book.</td>
+                                            </tr>
+                                            <tr>
+                                                <td>povCharacters</td>
+                                                <td>array of strings</td>
+                                                <td>An array of Character resource URLs that has had a POV-chapter in this book.</td>
+                                            </tr>
+                                        </tbody>
+                                    </table>
 
 
-//                                    <h5>Get specific character</h5>
-//                                    <select id="specificCharacter-lang">
-//                                        <option value="bash">cURL</option>
-//                                        <option value="python">Python</option>
-//                                        <option value="js">JavaScript</option>
-//                                    </select>
-//                                    <pre>
-//                                        <code class="language-bash line-numbers" id="specificCharacter-code">$ curl "https://www.anapioficeandfire.com/api/characters/823"</code>
-//                                    </pre>
-//                                    <p>
-//                                        <strong>Example response:</strong>
-//                                    </p>
-//                                    <pre><code class="language-json line-numbers">{
-//                                        "url": "https://www.anapioficeandfire.com/api/characters/823",
-//                                        "name": "Petyr Baelish",
-//                                        "culture": "Valemen",
-//                                        "born": "In 268 AC, at the Fingers",
-//                                        "died": "",
-//                                        "titles": [
-//                                        "Master of coin (formerly)",
-//                                        "Lord Paramount of the Trident",
-//                                        "Lord of Harrenhal",
-//                                        "Lord Protector of the Vale"
-//                                        ],
-//                                        "aliases": [
-//                                        "Littlefinger"
-//                                        ],
-//                                        "father": "",
-//                                        "mother": "",
-//                                        "spouse": "https://www.anapioficeandfire.com/api/characters/688",
-//                                        "allegiances": [
-//                                        "https://www.anapioficeandfire.com/api/houses/10",
-//                                        "https://www.anapioficeandfire.com/api/houses/11"
-//                                        ],
-//                                        "books": [
-//                                        "https://www.anapioficeandfire.com/api/books/1",
-//                                        ...
-//                                        ],
-//                                        "povBooks": [],
-//                                        "tvSeries": [
-//                                        "Season 1",
-//                                        "Season 2",
-//                                        "Season 3",
-//                                        "Season 4",
-//                                        "Season 5"
-//                                        ],
-//                                        "playedBy": [
-//                                        "Aidan Gillen"
-//                                        ]
-//}</code></pre>
-//                                    <p></p>
-//                                </div>
-//                                <div>
-//                                    <a name="houses"></a>
-//                                    <h4>Houses</h4>
-//                                    <p>A House is a house branch within the Ice And Fire universe.</p>
-//                                    <table>
-//                                        <thead>
-//                                            <tr>
-//                                                <th>Name</th>
-//                                                <th>Type</th>
-//                                                <th>Description</th>
-//                                            </tr>
-//                                        </thead>
-//                                        <tbody>
-//                                            <tr>
-//                                                <td>url</td>
-//                                                <td>string</td>
-//                                                <td>The hypermedia URL of this resource</td>
-//                                            </tr>
-//                                            <tr>
-//                                                <td>name</td>
-//                                                <td>string</td>
-//                                                <td>The name of this house</td>
-//                                            </tr>
-//                                            <tr>
-//                                                <td>region</td>
-//                                                <td>string</td>
-//                                                <td>The region that this house resides in.</td>
-//                                            </tr>
-//                                            <tr>
-//                                                <td>coatOfArms</td>
-//                                                <td>string</td>
-//                                                <td>Text describing the coat of arms of this house.</td>
-//                                            </tr>
-//                                            <tr>
-//                                                <td>words</td>
-//                                                <td>string</td>
-//                                                <td>The words of this house.</td>
-//                                            </tr>
-//                                            <tr>
-//                                                <td>titles</td>
-//                                                <td>array of strings</td>
-//                                                <td>The titles that this house holds.</td>
-//                                            </tr>
-//                                            <tr>
-//                                                <td>seats</td>
-//                                                <td>array of strings</td>
-//                                                <td>The seats that this house holds.</td>
-//                                            </tr>
-//                                            <tr>
-//                                                <td>currentLord</td>
-//                                                <td>string</td>
-//                                                <td>The Character resource URL of this house's current lord.</td>
-//                                            </tr>
-//                                            <tr>
-//                                                <td>heir</td>
-//                                                <td>string</td>
-//                                                <td>The Character resource URL of this house's heir.</td>
-//                                            </tr>
-//                                            <tr>
-//                                                <td>overlord</td>
-//                                                <td>string</td>
-//                                                <td>The House resource URL that this house answers to.</td>
-//                                            </tr>
-//                                            <tr>
-//                                                <td>founded</td>
-//                                                <td>string</td>
-//                                                <td>The year that this house was founded.</td>
-//                                            </tr>
-//                                            <tr>
-//                                                <td>founder</td>
-//                                                <td>string</td>
-//                                                <td>The Character resource URL that founded this house.</td>
-//                                            </tr>
-//                                            <tr>
-//                                                <td>diedOut</td>
-//                                                <td>string</td>
-//                                                <td>The year that this house died out.</td>
-//                                            </tr>
-//                                            <tr>
-//                                                <td>ancestralWeapons</td>
-//                                                <td>array of strings</td>
-//                                                <td>An array of names of the noteworthy weapons that this house owns.</td>
-//                                            </tr>
-//                                            <tr>
-//                                                <td>cadetBranches</td>
-//                                                <td>array of strings</td>
-//                                                <td>An array of House resource URLs that was founded from this house.</td>
-//                                            </tr>
-//                                            <tr>
-//                                                <td>swornMembers</td>
-//                                                <td>array of strings</td>
-//                                                <td>An array of Character resource URLs that are sworn to this house.</td>
-//                                            </tr>
-//                                        </tbody>
-//                                    </table>
+                                    <h5>List all books:</h5>
+                                    <select id="allBooks-lang">
+                                        <option value="bash">cURL</option>
+                                        <option value="python">Python</option>
+                                        <option value="js">JavaScript</option>
+                                    </select>
+                                    <pre>
+                                    <code class="language-bash line-numbers" id="allBooks-code">$ curl "https://www.anapioficeandfire.com/api/books"</code>
+                                    </pre>
+                                    <p>
+                                        <strong>Example response:</strong>
+                                    </p>
+                                    <pre><code class="language-json line-numbers">[
+  {
+    "url": "https://www.anapioficeandfire.com/api/books/1",
+    "name": "A Game of Thrones",
+    "isbn": "978-0553103540",
+    "authors": [
+      "George R. R. Martin"
+    ],
+    "numberOfPages": 694,
+    "publisher": "Bantam Books",
+    "country": "United States",
+    "mediaType": "Hardcover",
+    "released": "1996-08-01T00:00:00",
+    "characters": [
+      "https://www.anapioficeandfire.com/api/characters/2",
+      ...
+    ],
+    "povCharacters": [
+      "https://www.anapioficeandfire.com/api/characters/148",
+      ...
+    ]
+  },
+  {
+    "url": "https://www.anapioficeandfire.com/api/books/2",
+    "name": "A Clash of Kings",
+    "isbn": "978-0553108033",
+    "authors": [
+      "George R. R. Martin"
+    ],
+    "numberOfPages": 768,
+    "publisher": "Bantam Books",
+    "country": "United States",
+    "mediaType": "Hardcover",
+    "released": "1999-02-02T00:00:00",
+    "characters": [
+      "https://www.anapioficeandfire.com/api/characters/2",
+      ...
+    ],
+    "povCharacters": [
+      "https://www.anapioficeandfire.com/api/characters/148",
+      ...
+    ]
+  },
+  ...
+ ]</code></pre>
+                                    <p></p>
+                                    <h5>Filtering books</h5>
+                                    <p>You can also include filter parameters in your request to the books endpoint by including parameters in the query string.</p>
+                                    <table>
+                                        <thead>
+                                            <tr>
+                                                <th>Parameter</th>
+                                                <th>Type</th>
+                                                <th>Result</th>
+                                            </tr>
+                                        </thead>
+                                        <tbody>
+                                            <tr>
+                                                <td>name</td>
+                                                <td>string</td>
+                                                <td>Books with the given name are included in the response</td>
+                                            </tr>
+                                            <tr>
+                                                <td>fromReleaseDate</td>
+                                                <td>date</td>
+                                                <td>Books that were released after, or on, the given date are included in the response.</td>
+                                            </tr>
+                                            <tr>
+                                                <td>toReleaseDate</td>
+                                                <td>date</td>
+                                                <td>Books that were released before, or on, the given date are included in the response.</td>
+                                            </tr>
+                                        </tbody>
+                                    </table>
 
-//                                    <h5>List all houses:</h5>
-//                                    <select id="allHouses-lang">
-//                                        <option value="bash">cURL</option>
-//                                        <option value="python">Python</option>
-//                                        <option value="js">JavaScript</option>
-//                                    </select>
-//                                    <pre>
-//                                        <code class="language-bash line-numbers" id="allHouses-code">$ curl "https://www.anapioficeandfire.com/api/houses"</code>
-//                                    </pre>
-//                                    <p>
-//                                        <strong>Example response:</strong>
-//                                    </p>
-//                                    <pre><code class="language-json line-numbers">[
-//                                        {
-//                                            "url": "https://www.anapioficeandfire.com/api/houses/1",
-//                                        "name": "House Algood",
-//                                        "region": "The Westerlands",
-//                                        "coatOfArms": "A golden wreath, on a blue field with a gold border",
-//                                        "words": "",
-//                                        "titles": [],
-//                                        "seats": [],
-//                                        "currentLord": "",
-//                                        "heir": "",
-//                                        "overlord": "https://www.anapioficeandfire.com/api/houses/229",
-//                                        "founded": "",
-//                                        "founder": "",
-//                                        "diedOut": "",
-//                                        "ancestralWeapons": [],
-//                                        "cadetBranches": [],
-//                                        "swornMembers": []
-//  },
-//                                        {
-//                                            "url": "https://www.anapioficeandfire.com/api/houses/2",
-//                                        "name": "House Allyrion of Godsgrace",
-//                                        "region": "Dorne",
-//                                        "coatOfArms": "Gyronny Gules and Sable, a hand couped Or",
-//                                        "words": "No Foe May Pass",
-//                                        "titles": [],
-//                                        "seats": [
-//                                        "Godsgrace"
-//                                        ],
-//                                        "currentLord": "https://www.anapioficeandfire.com/api/characters/298",
-//                                        "heir": "https://www.anapioficeandfire.com/api/characters/1922",
-//                                        "overlord": "https://www.anapioficeandfire.com/api/houses/285",
-//                                        "founded": "",
-//                                        "founder": "",
-//                                        "diedOut": "",
-//                                        "ancestralWeapons": [],
-//                                        "cadetBranches": [],
-//                                        "swornMembers": [
-//                                        "https://www.anapioficeandfire.com/api/characters/1301",
-//                                        ...
-//                                        ]
-//  },
-//                                        ...
-//                                        ]</code></pre>
-//                                    <p></p>
+                                    <h5>Get specific book</h5>
+                                    <select id="specificBook-lang">
+                                        <option value="bash">cURL</option>
+                                        <option value="python">Python</option>
+                                        <option value="js">JavaScript</option>
+                                    </select>
+                                    <pre>
+                                        <code class="language-bash line-numbers" id="specificBook-code">$ curl "https://www.anapioficeandfire.com/api/books/1"</code>
+                                    </pre>
+                                    <p>
+                                        <strong>Example response:</strong>
+                                    </p>
+                                    <pre><code class="language-json line-numbers">{
+  "url": "https://www.anapioficeandfire.com/api/books/1",
+  "name": "A Game of Thrones",
+  "isbn": "978-0553103540",
+  "authors": [
+    "George R. R. Martin"
+  ],
+  "numberOfPages": 694,
+  "publisher": "Bantam Books",
+  "country": "United States",
+  "mediaType": "Hardcover",
+  "released": "1996-08-01T00:00:00",
+  "characters": [
+    "https://www.anapioficeandfire.com/api/characters/2",
+    ...
+  ],
+  "povCharacters": [
+    "https://www.anapioficeandfire.com/api/characters/148",
+    ...
+  ]
+}</code></pre>
+                                </div>
 
-//                                    <h5>Filtering houses</h5>
-//                                    <p>You can also include filter parameters in your request to the characters endpoint by including parameters in the query string.</p>
-//                                    <table>
-//                                        <thead>
-//                                            <tr>
-//                                                <th>Parameter</th>
-//                                                <th>Type</th>
-//                                                <th>Result</th>
-//                                            </tr>
-//                                        </thead>
-//                                        <tbody>
-//                                            <tr>
-//                                                <td>name</td>
-//                                                <td>string</td>
-//                                                <td>Houses with the given name are included in the response</td>
-//                                            </tr>
-//                                            <tr>
-//                                                <td>region</td>
-//                                                <td>string</td>
-//                                                <td>Houses that belong in the given region are included in the response.</td>
-//                                            </tr>
-//                                            <tr>
-//                                                <td>words</td>
-//                                                <td>string</td>
-//                                                <td>Houses that has the given words are included in the response.</td>
-//                                            </tr>
-//                                            <tr>
-//                                                <td>hasWords</td>
-//                                                <td>boolean</td>
-//                                                <td>Houses that have words (or not) are included in the response.</td>
-//                                            </tr>
-//                                            <tr>
-//                                                <td>hasTitles</td>
-//                                                <td>boolean</td>
-//                                                <td>Houses that have titles (or not) are included in the response.</td>
-//                                            </tr>
-//                                            <tr>
-//                                                <td>hasSeats</td>
-//                                                <td>boolean</td>
-//                                                <td>Houses that have seats (or not) are included in the response.</td>
-//                                            </tr>
-//                                            <tr>
-//                                                <td>hasDiedOut</td>
-//                                                <td>boolean</td>
-//                                                <td>Houses that are extinct are included in the response.</td>
-//                                            </tr>
-//                                            <tr>
-//                                                <td>hasAncestralWeapons</td>
-//                                                <td>boolean</td>
-//                                                <td>Houses that have ancestral weapons (or not) are included in the response.</td>
-//                                            </tr>
-//                                        </tbody>
-//                                    </table>
+                                <p></p>
+                                <div>
+                                    <a name="characters"></a>
+                                    <h4>Characters</h4>
+                                    <p>A Character is an individual within the Ice And Fire universe.</p>
+                                    <table>
+                                        <thead>
+                                            <tr>
+                                                <th>Name</th>
+                                                <th>Type</th>
+                                                <th>Description</th>
+                                            </tr>
+                                        </thead>
+                                        <tbody>
+                                            <tr>
+                                                <td>url</td>
+                                                <td>string</td>
+                                                <td>The hypermedia URL of this resource</td>
+                                            </tr>
+                                            <tr>
+                                                <td>name</td>
+                                                <td>string</td>
+                                                <td>The name of this character</td>
+                                            </tr>
+                                            <tr>
+                                                <td>gender</td>
+                                                <td>string</td>
+                                                <td>The gender of this character.</td>
+                                            </tr>
+                                            <tr>
+                                                <td>culture</td>
+                                                <td>string</td>
+                                                <td>The culture that this character belongs to.</td>
+                                            </tr>
+                                            <tr>
+                                                <td>born</td>
+                                                <td>string</td>
+                                                <td>Textual representation of when and where this character was born.</td>
+                                            </tr>
+                                            <tr>
+                                                <td>died</td>
+                                                <td>string</td>
+                                                <td>Textual representation of when and where this character died.</td>
+                                            </tr>
+                                            <tr>
+                                                <td>titles</td>
+                                                <td>array of strings</td>
+                                                <td>The titles that this character holds.</td>
+                                            </tr>
+                                            <tr>
+                                                <td>aliases</td>
+                                                <td>array of strings</td>
+                                                <td>The aliases that this character goes by.</td>
+                                            </tr>
+                                            <tr>
+                                                <td>father</td>
+                                                <td>string</td>
+                                                <td>The character resource URL of this character's father.</td>
+                                            </tr>
+                                            <tr>
+                                                <td>mother</td>
+                                                <td>string</td>
+                                                <td>The character resource URL of this character's mother.</td>
+                                            </tr>
+                                            <tr>
+                                                <td>spouse</td>
+                                                <td>string</td>
+                                                <td>An array of Character resource URLs that has had a POV-chapter in this book.</td>
+                                            </tr>
+                                            <tr>
+                                                <td>allegiances</td>
+                                                <td>array of strings</td>
+                                                <td>An array of House resource URLs that this character is loyal to.</td>
+                                            </tr>
+                                            <tr>
+                                                <td>books</td>
+                                                <td>array of strings</td>
+                                                <td>An array of Book resource URLs that this character has been in.</td>
+                                            </tr>
+                                            <tr>
+                                                <td>povBooks</td>
+                                                <td>array of strings</td>
+                                                <td>An array of Book resource URLs that this character has had a POV-chapter in.</td>
+                                            </tr>
+                                            <tr>
+                                                <td>tvSeries</td>
+                                                <td>array of strings</td>
+                                                <td>An array of names of the seasons of Game of Thrones that this character has been in.</td>
+                                            </tr>
+                                            <tr>
+                                                <td>playedBy</td>
+                                                <td>array of strings</td>
+                                                <td>An array of actor names that has played this character in the TV show Game Of Thrones.</td>
+                                            </tr>
+                                        </tbody>
+                                    </table>
+                                    <h5>List all characters:</h5>
+                                    <select id="allCharacters-lang">
+                                        <option value="bash">cURL</option>
+                                        <option value="python">Python</option>
+                                        <option value="js">JavaScript</option>
+                                    </select>
+                                    <pre>
+                                        <code class="language-bash line-numbers" id="allCharacters-code">$ curl "https://www.anapioficeandfire.com/api/characters"</code>
+                                    </pre>
+                                    <p>
+                                        <strong>Example response:</strong>
+                                    </p>
+                                    <pre><code class="language-json line-numbers">[
+  {
+    "url": "https://www.anapioficeandfire.com/api/characters/1",
+    "name": "",
+    "culture": "Braavosi",
+    "born": "",
+    "died": "",
+    "titles": [],
+    "aliases": [
+      "The Daughter of the Dusk"
+    ],
+    "father": "",
+    "mother": "",
+    "spouse": "",
+    "allegiances": [],
+    "books": [
+      "https://www.anapioficeandfire.com/api/books/5"
+    ],
+    "povBooks": [],
+    "tvSeries": [],
+    "playedBy": []
+  },
+  {
+    "url": "https://www.anapioficeandfire.com/api/characters/2",
+    "name": "",
+    "culture": "",
+    "born": "",
+    "died": "",
+    "titles": [],
+    "aliases": [
+      "Hodor"
+    ],
+    "father": "",
+    "mother": "",
+    "spouse": "",
+    "allegiances": [
+      "https://www.anapioficeandfire.com/api/houses/362"
+    ],
+    "books": [
+      "https://www.anapioficeandfire.com/api/books/1",
+      ...
+    ],
+    "povBooks": [],
+    "tvSeries": [
+      "Season 1",
+      "Season 2",
+      "Season 3",
+      "Season 4"
+    ],
+    "playedBy": [
+      "Kristian Nairn"
+    ]
+  },
+  ...
+]</code></pre>
+                                    <p></p>
+                                    <h5>Filtering characters</h5>
+                                    <p>You can also include filter parameters in your request to the characters endpoint by including parameters in the query string.</p>
+                                    <table>
+                                        <thead>
+                                            <tr>
+                                                <th>Parameter</th>
+                                                <th>Type</th>
+                                                <th>Result</th>
+                                            </tr>
+                                        </thead>
+                                        <tbody>
+                                            <tr>
+                                                <td>name</td>
+                                                <td>string</td>
+                                                <td>Characters with the given name are included in the response.</td>
+                                            </tr>
+                                            <tr>
+                                                <td>gender</td>
+                                                <td>string</td>
+                                                <td>Characters with the given gender are included in the response.</td>
+                                            </tr>
+                                            <tr>
+                                                <td>culture</td>
+                                                <td>string</td>
+                                                <td>Characters with the given culture are included in the response.</td>
+                                            </tr>
+                                            <tr>
+                                                <td>born</td>
+                                                <td>string</td>
+                                                <td>Characters that were born this given year are included in the response.</td>
+                                            </tr>
+                                            <tr>
+                                                <td>died</td>
+                                                <td>string</td>
+                                                <td>Characters that died this given year are included in the response.</td>
+                                            </tr>
+                                            <tr>
+                                                <td>isAlive</td>
+                                                <td>boolean</td>
+                                                <td>Characters that are alive or dead (depending on the value) are included in the response.</td>
+                                            </tr>
+                                        </tbody>
+                                    </table>
 
 
-//                                    <h5>Get specific house</h5>
-//                                    <select id="specificHouse-lang">
-//                                        <option value="bash">cURL</option>
-//                                        <option value="python">Python</option>
-//                                        <option value="js">JavaScript</option>
-//                                    </select>
-//                                    <pre>
-//                                        <code class="language-bash line-numbers" id="specificHouse-code">$ curl "https://www.anapioficeandfire.com/api/houses/10"</code>
-//                                    </pre>
-//                                    <p>
-//                                        <strong>Example response:</strong>
-//                                    </p>
-//                                    <pre><code class="language-json line-numbers">{
-//                                        "url": "https://www.anapioficeandfire.com/api/houses/10",
-//                                        "name": "House Baelish of Harrenhal",
-//                                        "region": "The Riverlands",
-//                                        "coatOfArms": "A field of silver mockingbirds, on a green field",
-//                                        "words": "",
-//                                        "titles": [
-//                                        "Lord Paramount of the Trident",
-//                                        "Lord of Harrenhal"
-//                                        ],
-//                                        "seats": [
-//                                        "Harrenhal"
-//                                        ],
-//                                        "currentLord": "https://www.anapioficeandfire.com/api/characters/823",
-//                                        "heir": "",
-//                                        "overlord": "https://www.anapioficeandfire.com/api/houses/16",
-//                                        "founded": "299 AC",
-//                                        "founder": "https://www.anapioficeandfire.com/api/characters/823",
-//                                        "diedOut": "",
-//                                        "ancestralWeapons": [],
-//                                        "cadetBranches": [],
-//                                        "swornMembers": [
-//                                        "https://www.anapioficeandfire.com/api/characters/651",
-//                                        "https://www.anapioficeandfire.com/api/characters/804",
-//                                        "https://www.anapioficeandfire.com/api/characters/823",
-//                                        "https://www.anapioficeandfire.com/api/characters/957",
-//                                        "https://www.anapioficeandfire.com/api/characters/970"
-//                                        ]
-//}</code></pre>
-//                                    <p></p>
-//                                </div>
-//                            </div>
+                                    <h5>Get specific character</h5>
+                                    <select id="specificCharacter-lang">
+                                        <option value="bash">cURL</option>
+                                        <option value="python">Python</option>
+                                        <option value="js">JavaScript</option>
+                                    </select>
+                                    <pre>
+                                        <code class="language-bash line-numbers" id="specificCharacter-code">$ curl "https://www.anapioficeandfire.com/api/characters/823"</code>
+                                    </pre>
+                                    <p>
+                                        <strong>Example response:</strong>
+                                    </p>
+                                    <pre><code class="language-json line-numbers">{
+  "url": "https://www.anapioficeandfire.com/api/characters/823",
+  "name": "Petyr Baelish",
+  "culture": "Valemen",
+  "born": "In 268 AC, at the Fingers",
+  "died": "",
+  "titles": [
+    "Master of coin (formerly)",
+    "Lord Paramount of the Trident",
+    "Lord of Harrenhal",
+    "Lord Protector of the Vale"
+  ],
+  "aliases": [
+    "Littlefinger"
+  ],
+  "father": "",
+  "mother": "",
+  "spouse": "https://www.anapioficeandfire.com/api/characters/688",
+  "allegiances": [
+    "https://www.anapioficeandfire.com/api/houses/10",
+    "https://www.anapioficeandfire.com/api/houses/11"
+  ],
+  "books": [
+    "https://www.anapioficeandfire.com/api/books/1",
+    ...
+  ],
+  "povBooks": [],
+  "tvSeries": [
+    "Season 1",
+    "Season 2",
+    "Season 3",
+    "Season 4",
+    "Season 5"
+  ],
+  "playedBy": [
+    "Aidan Gillen"
+  ]
+}</code></pre>
+                                    <p></p>
+                                </div>
+                                <div>
+                                    <a name="houses"></a>
+                                    <h4>Houses</h4>
+                                    <p>A House is a house branch within the Ice And Fire universe.</p>
+                                    <table>
+                                        <thead>
+                                            <tr>
+                                                <th>Name</th>
+                                                <th>Type</th>
+                                                <th>Description</th>
+                                            </tr>
+                                        </thead>
+                                        <tbody>
+                                            <tr>
+                                                <td>url</td>
+                                                <td>string</td>
+                                                <td>The hypermedia URL of this resource</td>
+                                            </tr>
+                                            <tr>
+                                                <td>name</td>
+                                                <td>string</td>
+                                                <td>The name of this house</td>
+                                            </tr>
+                                            <tr>
+                                                <td>region</td>
+                                                <td>string</td>
+                                                <td>The region that this house resides in.</td>
+                                            </tr>
+                                            <tr>
+                                                <td>coatOfArms</td>
+                                                <td>string</td>
+                                                <td>Text describing the coat of arms of this house.</td>
+                                            </tr>
+                                            <tr>
+                                                <td>words</td>
+                                                <td>string</td>
+                                                <td>The words of this house.</td>
+                                            </tr>
+                                            <tr>
+                                                <td>titles</td>
+                                                <td>array of strings</td>
+                                                <td>The titles that this house holds.</td>
+                                            </tr>
+                                            <tr>
+                                                <td>seats</td>
+                                                <td>array of strings</td>
+                                                <td>The seats that this house holds.</td>
+                                            </tr>
+                                            <tr>
+                                                <td>currentLord</td>
+                                                <td>string</td>
+                                                <td>The Character resource URL of this house's current lord.</td>
+                                            </tr>
+                                            <tr>
+                                                <td>heir</td>
+                                                <td>string</td>
+                                                <td>The Character resource URL of this house's heir.</td>
+                                            </tr>
+                                            <tr>
+                                                <td>overlord</td>
+                                                <td>string</td>
+                                                <td>The House resource URL that this house answers to.</td>
+                                            </tr>
+                                            <tr>
+                                                <td>founded</td>
+                                                <td>string</td>
+                                                <td>The year that this house was founded.</td>
+                                            </tr>
+                                            <tr>
+                                                <td>founder</td>
+                                                <td>string</td>
+                                                <td>The Character resource URL that founded this house.</td>
+                                            </tr>
+                                            <tr>
+                                                <td>diedOut</td>
+                                                <td>string</td>
+                                                <td>The year that this house died out.</td>
+                                            </tr>
+                                            <tr>
+                                                <td>ancestralWeapons</td>
+                                                <td>array of strings</td>
+                                                <td>An array of names of the noteworthy weapons that this house owns.</td>
+                                            </tr>
+                                            <tr>
+                                                <td>cadetBranches</td>
+                                                <td>array of strings</td>
+                                                <td>An array of House resource URLs that was founded from this house.</td>
+                                            </tr>
+                                            <tr>
+                                                <td>swornMembers</td>
+                                                <td>array of strings</td>
+                                                <td>An array of Character resource URLs that are sworn to this house.</td>
+                                            </tr>
+                                        </tbody>
+                                    </table>
 
-//                            @Html.Partial("_Libraries")
-//                        </div>
-//                        <div class="small-12 medium-4 column hide-for-small-only">
-//                            @Html.Partial("_Menu")
-//                        </div>
-//                    </div>
-//                </article>
-//            </div>
-//        </section>
-//    </div >
-//</div >`
+                                    <h5>List all houses:</h5>
+                                    <select id="allHouses-lang">
+                                        <option value="bash">cURL</option>
+                                        <option value="python">Python</option>
+                                        <option value="js">JavaScript</option>
+                                    </select>
+                                    <pre>
+                                        <code class="language-bash line-numbers" id="allHouses-code">$ curl "https://www.anapioficeandfire.com/api/houses"</code>
+                                    </pre>
+                                    <p>
+                                        <strong>Example response:</strong>
+                                    </p>
+                                    <pre><code class="language-json line-numbers">[
+  {
+    "url": "https://www.anapioficeandfire.com/api/houses/1",
+    "name": "House Algood",
+    "region": "The Westerlands",
+    "coatOfArms": "A golden wreath, on a blue field with a gold border",
+    "words": "",
+    "titles": [],
+    "seats": [],
+    "currentLord": "",
+    "heir": "",
+    "overlord": "https://www.anapioficeandfire.com/api/houses/229",
+    "founded": "",
+    "founder": "",
+    "diedOut": "",
+    "ancestralWeapons": [],
+    "cadetBranches": [],
+    "swornMembers": []
+  },
+  {
+    "url": "https://www.anapioficeandfire.com/api/houses/2",
+    "name": "House Allyrion of Godsgrace",
+    "region": "Dorne",
+    "coatOfArms": "Gyronny Gules and Sable, a hand couped Or",
+    "words": "No Foe May Pass",
+    "titles": [],
+    "seats": [
+      "Godsgrace"
+    ],
+    "currentLord": "https://www.anapioficeandfire.com/api/characters/298",
+    "heir": "https://www.anapioficeandfire.com/api/characters/1922",
+    "overlord": "https://www.anapioficeandfire.com/api/houses/285",
+    "founded": "",
+    "founder": "",
+    "diedOut": "",
+    "ancestralWeapons": [],
+    "cadetBranches": [],
+    "swornMembers": [
+      "https://www.anapioficeandfire.com/api/characters/1301",
+      ...
+    ]
+  },
+  ...
+]</code></pre>
+                                    <p></p>
+
+                                    <h5>Filtering houses</h5>
+                                    <p>You can also include filter parameters in your request to the characters endpoint by including parameters in the query string.</p>
+                                    <table>
+                                        <thead>
+                                            <tr>
+                                                <th>Parameter</th>
+                                                <th>Type</th>
+                                                <th>Result</th>
+                                            </tr>
+                                        </thead>
+                                        <tbody>
+                                            <tr>
+                                                <td>name</td>
+                                                <td>string</td>
+                                                <td>Houses with the given name are included in the response</td>
+                                            </tr>
+                                            <tr>
+                                                <td>region</td>
+                                                <td>string</td>
+                                                <td>Houses that belong in the given region are included in the response.</td>
+                                            </tr>
+                                            <tr>
+                                                <td>words</td>
+                                                <td>string</td>
+                                                <td>Houses that has the given words are included in the response.</td>
+                                            </tr>
+                                            <tr>
+                                                <td>hasWords</td>
+                                                <td>boolean</td>
+                                                <td>Houses that have words (or not) are included in the response.</td>
+                                            </tr>
+                                            <tr>
+                                                <td>hasTitles</td>
+                                                <td>boolean</td>
+                                                <td>Houses that have titles (or not) are included in the response.</td>
+                                            </tr>
+                                            <tr>
+                                                <td>hasSeats</td>
+                                                <td>boolean</td>
+                                                <td>Houses that have seats (or not) are included in the response.</td>
+                                            </tr>
+                                            <tr>
+                                                <td>hasDiedOut</td>
+                                                <td>boolean</td>
+                                                <td>Houses that are extinct are included in the response.</td>
+                                            </tr>
+                                            <tr>
+                                                <td>hasAncestralWeapons</td>
+                                                <td>boolean</td>
+                                                <td>Houses that have ancestral weapons (or not) are included in the response.</td>
+                                            </tr>
+                                        </tbody>
+                                    </table>
+
+
+                                    <h5>Get specific house</h5>
+                                    <select id="specificHouse-lang">
+                                        <option value="bash">cURL</option>
+                                        <option value="python">Python</option>
+                                        <option value="js">JavaScript</option>
+                                    </select>
+                                    <pre>
+                                        <code class="language-bash line-numbers" id="specificHouse-code">$ curl "https://www.anapioficeandfire.com/api/houses/10"</code>
+                                    </pre>
+                                    <p>
+                                        <strong>Example response:</strong>
+                                    </p>
+                                    <pre><code class="language-json line-numbers">{
+  "url": "https://www.anapioficeandfire.com/api/houses/10",
+  "name": "House Baelish of Harrenhal",
+  "region": "The Riverlands",
+  "coatOfArms": "A field of silver mockingbirds, on a green field",
+  "words": "",
+  "titles": [
+    "Lord Paramount of the Trident",
+    "Lord of Harrenhal"
+  ],
+  "seats": [
+    "Harrenhal"
+  ],
+  "currentLord": "https://www.anapioficeandfire.com/api/characters/823",
+  "heir": "",
+  "overlord": "https://www.anapioficeandfire.com/api/houses/16",
+  "founded": "299 AC",
+  "founder": "https://www.anapioficeandfire.com/api/characters/823",
+  "diedOut": "",
+  "ancestralWeapons": [],
+  "cadetBranches": [],
+  "swornMembers": [
+    "https://www.anapioficeandfire.com/api/characters/651",
+    "https://www.anapioficeandfire.com/api/characters/804",
+    "https://www.anapioficeandfire.com/api/characters/823",
+    "https://www.anapioficeandfire.com/api/characters/957",
+    "https://www.anapioficeandfire.com/api/characters/970"
+  ]
+}</code></pre>
+                                    <p></p>
+                                </div>
+                            </div>
+
+                            @Html.Partial("_Libraries")
+                        </div>
+                        <div class="small-12 medium-4 column hide-for-small-only">
+                            @Html.Partial("_Menu")
+                        </div>
+                    </div>
+                </article>
+            </div>
+        </section>
+    </div>
+</div>`


### PR DESCRIPTION
## Summary of changes:
- Added code examples with syntax highlighting for making requests to each endpoint with Python and JavaScript, in addition to the current examples with cURL. The dropdown menu above the example for each resource is updated for all menus when the selection for one menu changes. In other words, if the user selects Python for the root resource (or any other resource), examples are shown in Python for all other resources as well.
- Added syntax highlighting for the example data returned from each resource.
- Updated the styling slightly so all code on the page is displayed in block format.
- Added instructions for setting up a local development environment in CONTRIBUTING.md.
- Added instructions for running the front end tests in CONTRIBUTING.md.
- Added frontend tests in AnApiOfIceAndFire\tests\AnApiOfIceAndFire.Tests\Views\test.js for the functions in AnApiOfIceAndFire\src\AnApiOfIceAndFire\wwwroot\scripts.js.

### Regarding the frontend tests:
I wanted to write tests for the JavaScript code I added, however I haven't worked much with .NET and I had a lot of trouble getting the test runner I decided on, Chutzpah, to do what I wanted it to do. There's a note in CONTRIBUTING.md about this, but to reiterate here, the tests in the first two describe functions pass if executed with Chutzpah, however, the tests in the third function will error out with a message about a reference to JSDOM. I wasn't able to figure out how to pass in a reference to JSDOM, and also didn't see anything in Chutzpah's documentation about marking tests to skip. Though the tests don't all pass currently, they do pass if they have access to the necessary dependencies. I made note of a couple TODO items that would make running the tests possible and more maintainable.

Please let me know if any changes are necessary prior to merging and I'd be happy to work on those.